### PR TITLE
External Lua Library Support

### DIFF
--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -52,7 +52,7 @@ public:
     void Push() {} // Base case
     
     void OpenLib(const std::string& modname, lua_CFunction openf) {
-        luaL_requireF(_l, modname, openf, 0);
+        luaL_requiref(_l, modname, openf, 1);
     }
 
     template <typename T, typename... Ts>


### PR DESCRIPTION
While using Selene, I realized it only had one option for setting the active libraries for Lua scripts, in constructor of sel::State. 

In some cases (modding ability in game dev for example), you don't want Lua to have access to some libraries (io, os, etc). 

So, I came up with a new function for sel::State that does the job. It essentially just ends up being a wrapper due to the lua_State being private.

The parameters are:
modname - the Lua name of the library (the "table" part of "table.insert()")
openf - the function Lua uses to open the library. 

There is nothing to return as [luaL_requiref](http://www.lua.org/manual/5.2/manual.html#luaL_requiref) doesn't return anything. 

The function adheres to the [Lua manuals directions](http://www.lua.org/manual/5.2/manual.html#6).

If you would like test cases, I can give them to you.
