### PR TITLE
External Lua Library Support

### DIFF
--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -48,6 +48,10 @@ public:
     bool Load(const std::string &file) {
         return !luaL_dofile(_l, file.c_str());
     }
+    
+    void OpenLib(const std::string& modname, lua_CFunction openf) {
+        luaL_requiref(_l, modname, openf, 1);
+    }
 
     void Push() {} // Base case
 


### PR DESCRIPTION
While using Selene, I realized it only had one option for setting the active libraries for Lua scripts, in constructor of sel::State.

In some cases (modding ability in game dev for example), you don't want Lua to have access to some libraries (io, os, etc).

So, I came up with a new function for sel::State that does the job. It essentially just ends up being a wrapper due to the lua_State being private.

The parameters are:
modname - the Lua name of the library (the "table" part of "table.insert()")
openf - the function Lua uses to open the library.

There is nothing to return as luaL_requiref doesn't return anything.

The function adheres to the Lua manuals directions.

If you would like test cases, I can give them to you.
