### PR TITLE
Fix string conversion introduced with OpenLib.

### DIFF
--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -50,7 +50,7 @@ public:
     }
     
     void OpenLib(const std::string& modname, lua_CFunction openf) {
-        luaL_requiref(_l, modname, openf, 1);
+        luaL_requiref(_l, modname.c_str(), openf, 1);
     }
 
     void Push() {} // Base case


### PR DESCRIPTION
no known conversion from 'const std::string' to 'const char*'
