### PR TITLE
Fix warnings when compiling with VS2013 Nov CTP

### DIFF
--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -55,7 +55,7 @@ inline T& _get(_id<T&>, lua_State *l, const int index) {
 }
 
 inline bool _get(_id<bool>, lua_State *l, const int index) {
-    return lua_toboolean(l, index);
+    return lua_toboolean(l, index) != 0;
 }
 
 inline int _get(_id<int>, lua_State *l, const int index) {
@@ -101,7 +101,7 @@ inline lua_Number _check_get(_id<lua_Number>, lua_State *l, const int index) {
 }
 
 inline bool _check_get(_id<bool>, lua_State *l, const int index) {
-    return lua_toboolean(l, index);
+    return lua_toboolean(l, index) != 0;
 }
 
 inline std::string _check_get(_id<std::string>, lua_State *l, const int index) {


### PR DESCRIPTION
These two lines caused a C4800 warning when compiling with the Nov 2013 Visual C++ compiler CTP.
(e.g. selene\primitives.h(58): warning C4800: 'int' : forcing value to bool 'true' or 'false' (performance warning))

Thanks for Selene by the way, by far the most readable and convenient approach to C++/Lua integration I've seen to date.
