### PR TITLE
Support for float as numeric type.

### DIFF
--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -100,6 +100,10 @@ inline lua_Number _check_get(_id<lua_Number>, lua_State *l, const int index) {
     return luaL_checknumber(l, index);
 }
 
+inline float _check_get(_id<float>, lua_State *l, const int index) {
+	return luaL_checknumber(l, index);
+}
+
 inline bool _check_get(_id<bool>, lua_State *l, const int index) {
     return lua_toboolean(l, index) != 0;
 }


### PR DESCRIPTION
Discovered that there was no support for float when trying to expose a class member variable.
