### PR TITLE
Define constexpr not available in VS2013

### DIFF
--- a/include/selene.h
+++ b/include/selene.h
@@ -1,4 +1,8 @@
 #pragma once
 
+#if defined(_MSC_VER) && _MSC_VER < 1900 // before MSVS-14 CTP1
+#define constexpr const
+#endif
+
 #include "selene/State.h"
 #include "selene/Tuple.h"


### PR DESCRIPTION
I am not sure where to put this in order to cover all instances of constexpr, so i include it in selene.h