### PR TITLE
Improvements in CMakeLists.txt to support various non-standard Lua configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(Selene)
 
-set(LUA_INCLUDE_DIR "" CACHE FILEPATH "Path to lua headers")
+set(LUA_PC_CFG "lua;lua5.3;lua5.2;lua5.1" CACHE STRING "pkg-config Lua configuration file (or files, separated by ;)")
+
+find_package(PkgConfig)
+pkg_search_module(LUA REQUIRED ${LUA_PC_CFG})
 
 if(${LUA_INCLUDE_DIR})
   if(NOT EXISTS ${LUA_INCLUDE_DIR}/lua.h)
@@ -24,4 +27,4 @@ file(GLOB headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   include/*.h include/selene/*.h)
 
 add_executable(test_runner ${CMAKE_CURRENT_SOURCE_DIR}/test/Test.cpp)
-target_link_libraries(test_runner lua)
+target_link_libraries(test_runner ${LUA_LIBRARIES})


### PR DESCRIPTION
Some distros (particularly, Debian & derivatives) allow co-existance of
different Lua versions. Each version has its own .pc configuration.
This commit makes use of .pc config (lua.pc by default) and allows
specification of a particular configuration file
(e.g. -DLUA_PC_CFG=lua5.3)