### PR TITLE
Add user defined error handler.

### DIFF
--- a/include/selene/Constants.h
+++ b/include/selene/Constants.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace sel {
+    constexpr int ErrorHandlerIndex = 1;
+}

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Constants.h"
 #include "exotics.h"
 #include <functional>
 #include "Registry.h"
@@ -127,7 +128,7 @@ public:
             _get();
             _functor(0);
         }
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     // Allow automatic casting when used in comparisons
@@ -140,25 +141,9 @@ public:
         Selector copy{*this};
         const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
         copy._functor = [state, tuple_args, num_args](int num_ret) {
-            // install handler, and swap(handler, function) on lua stack
-            int handler_index = SetErrorHandler(state);
-            int func_index = handler_index - 1;
-#if LUA_VERSION_NUM >= 502
-            lua_pushvalue(state, func_index);
-            lua_copy(state, handler_index, func_index);
-            lua_replace(state, handler_index);
-#else
-            lua_pushvalue(state, func_index);
-            lua_push_value(state, handler_index);
-            lua_replace(state, func_index);
-            lua_replace(state, handler_index);
-#endif
             // call lua function with error handler
             detail::_push(state, tuple_args);
-            lua_pcall(state, num_args, num_ret, handler_index - 1);
-
-            // remove error handler
-            lua_remove(state, handler_index - 1);
+            lua_pcall(state, num_args, num_ret, ErrorHandlerIndex);
         };
         return copy;
     }
@@ -170,7 +155,7 @@ public:
             _registry.Register(lambda);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
 
@@ -180,7 +165,7 @@ public:
             detail::_push(_state, b);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     void operator=(int i) const {
@@ -189,7 +174,7 @@ public:
             detail::_push(_state, i);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     void operator=(unsigned int i) const {
@@ -198,7 +183,7 @@ public:
             detail::_push(_state, i);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     void operator=(lua_Number n) const {
@@ -207,7 +192,7 @@ public:
             detail::_push(_state, n);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     void operator=(const std::string &s) const {
@@ -216,7 +201,7 @@ public:
             detail::_push(_state, s);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     template <typename Ret, typename... Args>
@@ -243,7 +228,7 @@ public:
             detail::_push(_state, std::string{s});
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     template <typename T, typename... Funs>
@@ -254,7 +239,7 @@ public:
             _registry.Register(t, fun_tuple);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     template <typename T, typename... Args, typename... Funs>
@@ -266,7 +251,7 @@ public:
             _registry.RegisterClass<T, Args...>(_name, fun_tuple, d);
         };
         _put(push);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     template <typename... Ret>
@@ -286,7 +271,7 @@ public:
             _functor = nullptr;
         }
         auto ret = detail::_pop(detail::_id<T*>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return *ret;
     }
 
@@ -299,7 +284,7 @@ public:
             _functor = nullptr;
         }
         auto ret = detail::_pop(detail::_id<T*>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -311,7 +296,7 @@ public:
             _functor = nullptr;
         }
         auto ret = detail::_pop(detail::_id<bool>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -323,7 +308,7 @@ public:
             _functor = nullptr;
         }
         auto ret = detail::_pop(detail::_id<int>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -335,7 +320,7 @@ public:
             _functor = nullptr;
         }
         auto ret = detail::_pop(detail::_id<unsigned int>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -347,7 +332,7 @@ public:
             _functor = nullptr;
         }
         auto ret = detail::_pop(detail::_id<lua_Number>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -359,7 +344,7 @@ public:
             _functor = nullptr;
         }
         auto ret =  detail::_pop(detail::_id<std::string>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -373,7 +358,7 @@ public:
         }
         auto ret = detail::_pop(detail::_id<sel::function<R(Args...)>>{},
                                 _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -469,7 +454,7 @@ private:
             _functor = nullptr;
         }
         auto ret =  detail::_pop(detail::_id<std::string>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 };

--- a/include/selene/function.h
+++ b/include/selene/function.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Constants.h"
 #include <functional>
 #include "LuaRef.h"
 #include <memory>
@@ -22,14 +23,12 @@ public:
     function(int ref, lua_State *state) : _ref(state, ref), _state(state) {}
 
     R operator()(Args... args) {
-        int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
-        lua_pcall(_state, num_args, 1, handler_index);
-        lua_remove(_state, handler_index);
+        lua_pcall(_state, num_args, 1, ErrorHandlerIndex);
         R ret = detail::_pop(detail::_id<R>{}, _state);
-        lua_settop(_state, 0);
+        lua_settop(_state, ErrorHandlerIndex);
         return ret;
     }
 
@@ -47,13 +46,11 @@ public:
     function(int ref, lua_State *state) : _ref(state, ref), _state(state) {}
 
     void operator()(Args... args) {
-        int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
-        lua_pcall(_state, num_args, 1, handler_index);
-        lua_remove(_state, handler_index);
-        lua_settop(_state, 0);
+        lua_pcall(_state, num_args, 1, ErrorHandlerIndex);
+        lua_settop(_state, ErrorHandlerIndex);
     }
 
     void Push(lua_State *state) {
@@ -71,13 +68,11 @@ public:
     function(int ref, lua_State *state) : _ref(state, ref), _state(state) {}
 
     std::tuple<R...> operator()(Args... args) {
-        int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
         constexpr int num_ret = sizeof...(R);
-        lua_pcall(_state, num_args, num_ret, handler_index);
-        lua_remove(_state, handler_index);
+        lua_pcall(_state, num_args, num_ret, ErrorHandlerIndex);
         return detail::_pop_n_reset<R...>(_state);
     }
 

--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Constants.h"
 #include <string>
 #include "traits.h"
 #include "MetatableRegistry.h"
@@ -175,12 +176,12 @@ struct _pop_n_reset_impl {
     template <std::size_t... N>
     static type worker(lua_State *l,
                        _indices<N...>) {
-        return std::make_tuple(_get(_id<Ts>{}, l, N + 1)...);
+        return std::make_tuple(_get(_id<Ts>{}, l, N + ErrorHandlerIndex + 1)...);
     }
 
     static type apply(lua_State *l) {
         auto ret = worker(l, typename _indices_builder<S>::type());
-        lua_settop(l, 0);
+        lua_settop(l, ErrorHandlerIndex);
         return ret;
     }
 };
@@ -190,7 +191,7 @@ template <typename... Ts>
 struct _pop_n_reset_impl<0, Ts...> {
     using type = void;
     static type apply(lua_State *l) {
-        lua_settop(l, 0);
+        lua_settop(l, ErrorHandlerIndex);
     }
 };
 
@@ -200,7 +201,7 @@ struct _pop_n_reset_impl<1, T> {
     using type = T;
     static type apply(lua_State *l) {
         T ret = _get(_id<T>{}, l, -1);
-        lua_settop(l, 0);
+        lua_settop(l, ErrorHandlerIndex);
         return ret;
     }
 };

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -16,6 +16,7 @@ using TestMap = std::map<const char *, Test>;
 static TestMap tests = {
     {"test_load_error", test_load_error},
     {"test_load_syntax_error", test_load_syntax_error},
+    {"test_alternate_error_handler", test_alternate_error_handler},
     {"test_call_undefined_function", test_call_undefined_function},
     {"test_call_undefined_function2", test_call_undefined_function2},
     {"test_call_stackoverflow", test_call_stackoverflow},
@@ -111,9 +112,15 @@ int ExecuteAll() {
                                it->first + "\" failed.");
         }
         int size = state.Size();
-        if (size != 0) {
+        if (size > sel::ErrorHandlerIndex) {
             failures.push_back(std::string{"Test \""} + it->first
                                + "\" leaked " + std::to_string(size) + " values");
+            std::cout << state << std::endl;
+        }
+        else if(size < sel::ErrorHandlerIndex)
+        {
+            failures.push_back(std::string{"Test \""} + it->first
+                               + "\" corrupted stack");
             std::cout << state << std::endl;
         }
     }
@@ -142,7 +149,7 @@ bool ExecuteTest(const char *test) {
 int main() {
     // Executing all tests will run all test cases and check leftover
     // stack size afterwards. It is expected that the stack size
-    // post-test is 0.
+    // post-test is 1.
     return ExecuteAll();
 
     // For debugging anything in particular, you can run an individual

--- a/test/error_tests.h
+++ b/test/error_tests.h
@@ -39,6 +39,19 @@ bool test_load_syntax_error(sel::State &state) {
         && capture.Content().find(expected) != std::string::npos;
 }
 
+bool test_alternate_error_handler(sel::State &) {
+    auto prefixingPrint = [](std::string const& msg)
+    {
+        std::cout << "Selene-Lib: " << msg << std::endl;
+    };
+    sel::State state{true, prefixingPrint};
+    state.Load("../test/test_error.lua");
+    const char* expected = "Selene-Lib: attempt to call a nil value";
+    CapturedStdout capture;
+    state["undefined_function"]();
+    return capture.Content().find(expected) != std::string::npos;
+}
+
 bool test_call_undefined_function(sel::State &state) {
     state.Load("../test/test_error.lua");
     const char* expected = "attempt to call a nil value";


### PR DESCRIPTION
The user defined error handler is kept on the stack at index 1. This relieves sel::Selector::operator() and sel::function::operator() from the obligation to push and pop the error handler on each call.

This is the first Step to fulfil #95. Handling of exceptions is still missing.