### PR TITLE
Interop: references to primitives

### DIFF
--- a/include/selene/Fun.h
+++ b/include/selene/Fun.h
@@ -2,13 +2,14 @@
 
 #include "BaseFun.h"
 #include "MetatableRegistry.h"
+#include "primitives.h"
 #include <string>
 
 namespace sel {
 template <int N, typename Ret, typename... Args>
 class Fun : public BaseFun {
 private:
-    using _fun_type = std::function<Ret(Args...)>;
+    using _fun_type = std::function<Ret(detail::decay_primitive<Args>...)>;
     _fun_type _fun;
     MetatableRegistry &_meta_registry;
 
@@ -23,7 +24,8 @@ public:
     // Each application of a function receives a new Lua context so
     // this argument is necessary.
     int Apply(lua_State *l) override {
-        std::tuple<Args...> args = detail::_get_args<Args...>(l);
+        std::tuple<detail::decay_primitive<Args>...> args =
+            detail::_get_args<detail::decay_primitive<Args>...>(l);
         Ret value = detail::_lift(_fun, args);
         detail::_push(l, _meta_registry, std::forward<Ret>(value));
         return N;
@@ -34,7 +36,7 @@ public:
 template <typename... Args>
 class Fun<0, void, Args...> : public BaseFun {
 private:
-    using _fun_type = std::function<void(Args...)>;
+    using _fun_type = std::function<void(detail::decay_primitive<Args>...)>;
     _fun_type _fun;
 
 public:
@@ -48,7 +50,8 @@ public:
     // Each application of a function receives a new Lua context so
     // this argument is necessary.
     int Apply(lua_State *l) {
-        std::tuple<Args...> args = detail::_get_args<Args...>(l);
+        std::tuple<detail::decay_primitive<Args>...> args =
+            detail::_get_args<detail::decay_primitive<Args>...>(l);
         detail::_lift(_fun, args);
         return 0;
     }

--- a/include/selene/Fun.h
+++ b/include/selene/Fun.h
@@ -15,11 +15,6 @@ private:
 public:
     Fun(lua_State *&l,
         MetatableRegistry &meta_registry,
-        Ret(*fun)(Args...))
-        : Fun(l, meta_registry, _fun_type{fun}) {}
-
-    Fun(lua_State *&l,
-        MetatableRegistry &meta_registry,
         _fun_type fun) : _fun(fun), _meta_registry(meta_registry) {
         lua_pushlightuserdata(l, (void *)static_cast<BaseFun *>(this));
         lua_pushcclosure(l, &detail::_lua_dispatcher, 1);
@@ -43,11 +38,6 @@ private:
     _fun_type _fun;
 
 public:
-    Fun(lua_State *&l,
-        MetatableRegistry &dummy,
-        void(*fun)(Args...))
-        : Fun(l, dummy, _fun_type{fun}) {}
-
     Fun(lua_State *&l,
         MetatableRegistry &,
         _fun_type fun) : _fun(fun) {

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -277,7 +277,12 @@ public:
         return detail::_pop_n_reset<Ret...>(_state);
     }
 
-    template <typename T>
+    template<
+        typename T,
+        typename = typename std::enable_if<
+            !detail::is_primitive<typename std::decay<T>::type>::value
+        >::type
+    >
     operator T&() const {
         _traverse();
         _get();

--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include "traits.h"
+#include <type_traits>
 #include "MetatableRegistry.h"
 
 extern "C" {
@@ -41,6 +42,14 @@ template <>
 struct is_primitive<std::string> {
     static constexpr bool value = true;
 };
+
+template<typename T>
+using decay_primitive =
+    typename std::conditional<
+        is_primitive<typename std::decay<T>::type>::value,
+        typename std::decay<T>::type,
+        T
+    >::type;
 
 /* getters */
 template <typename T>

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -43,7 +43,6 @@ static TestMap tests = {
     {"test_get_primitive_by_value", test_get_primitive_by_value},
     {"test_get_primitive_by_const_ref", test_get_primitive_by_const_ref},
     {"test_get_primitive_by_rvalue_ref", test_get_primitive_by_rvalue_ref},
-    {"test_get_primitive_by_ref", test_get_primitive_by_ref},
     {"test_call_with_primitive_by_value", test_call_with_primitive_by_value},
     {"test_call_with_primitive_by_const_ref", test_call_with_primitive_by_const_ref},
     {"test_call_with_primitive_by_rvalue_ref", test_call_with_primitive_by_rvalue_ref},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -42,9 +42,11 @@ static TestMap tests = {
     {"test_nullptr_to_nil", test_nullptr_to_nil},
     {"test_get_primitive_by_value", test_get_primitive_by_value},
     {"test_get_primitive_by_const_ref", test_get_primitive_by_const_ref},
+    {"test_get_primitive_by_rvalue_ref", test_get_primitive_by_rvalue_ref},
     {"test_get_primitive_by_ref", test_get_primitive_by_ref},
     {"test_call_with_primitive_by_value", test_call_with_primitive_by_value},
     {"test_call_with_primitive_by_const_ref", test_call_with_primitive_by_const_ref},
+    {"test_call_with_primitive_by_rvalue_ref", test_call_with_primitive_by_rvalue_ref},
 
     {"test_metatable_registry_ptr", test_metatable_registry_ptr},
     {"test_metatable_registry_ref", test_metatable_registry_ref},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -40,6 +40,11 @@ static TestMap tests = {
     {"test_pointer_return", test_pointer_return},
     {"test_reference_return", test_reference_return},
     {"test_nullptr_to_nil", test_nullptr_to_nil},
+    {"test_get_primitive_by_value", test_get_primitive_by_value},
+    {"test_get_primitive_by_const_ref", test_get_primitive_by_const_ref},
+    {"test_get_primitive_by_ref", test_get_primitive_by_ref},
+    {"test_call_with_primitive_by_value", test_call_with_primitive_by_value},
+    {"test_call_with_primitive_by_const_ref", test_call_with_primitive_by_const_ref},
 
     {"test_metatable_registry_ptr", test_metatable_registry_ptr},
     {"test_metatable_registry_ref", test_metatable_registry_ref},

--- a/test/interop_tests.h
+++ b/test/interop_tests.h
@@ -183,12 +183,18 @@ bool test_get_primitive_by_value(sel::State & state) {
 
 bool test_get_primitive_by_const_ref(sel::State & state) {
     state.Load("../test/test.lua");
+    // Crashes
     return static_cast<const int &>(state["global1"]) == 5;
+}
+
+bool test_get_primitive_by_rvalue_ref(sel::State & state) {
+    state.Load("../test/test.lua");
+    return static_cast<int &&>(state["global1"]) == 5;
 }
 
 bool test_get_primitive_by_ref(sel::State & state) {
     state.Load("../test/test.lua");
-    // This should not even compile, should it?
+    // This should not even compile.
     return static_cast<int &>(state["global1"]) == 5;
 }
 
@@ -205,6 +211,17 @@ bool test_call_with_primitive_by_const_ref(sel::State & state) {
     auto const accept_int_by_const_ref =
         [&success](const int & x) {success = x == 5;};
     state["test"] = accept_int_by_const_ref;
+    // Crashes
+    state["test"](5);
+    return success;
+}
+
+bool test_call_with_primitive_by_rvalue_ref(sel::State & state) {
+    bool success = false;
+    auto const accept_int_by_rvalue_ref =
+        [&success](int && x) {success = x == 5;};
+    // This should compile.
+    state["test"] = accept_int_by_rvalue_ref;
     state["test"](5);
     return success;
 }

--- a/test/interop_tests.h
+++ b/test/interop_tests.h
@@ -211,7 +211,6 @@ bool test_call_with_primitive_by_const_ref(sel::State & state) {
     auto const accept_int_by_const_ref =
         [&success](const int & x) {success = x == 5;};
     state["test"] = accept_int_by_const_ref;
-    // Crashes
     state["test"](5);
     return success;
 }
@@ -220,7 +219,6 @@ bool test_call_with_primitive_by_rvalue_ref(sel::State & state) {
     bool success = false;
     auto const accept_int_by_rvalue_ref =
         [&success](int && x) {success = x == 5;};
-    // This should compile.
     state["test"] = accept_int_by_rvalue_ref;
     state["test"](5);
     return success;

--- a/test/interop_tests.h
+++ b/test/interop_tests.h
@@ -175,3 +175,36 @@ bool test_nullptr_to_nil(sel::State &state) {
     state("result = x == nil");
     return static_cast<bool>(state["result"]);
 }
+
+bool test_get_primitive_by_value(sel::State & state) {
+    state.Load("../test/test.lua");
+    return static_cast<int>(state["global1"]) == 5;
+}
+
+bool test_get_primitive_by_const_ref(sel::State & state) {
+    state.Load("../test/test.lua");
+    return static_cast<const int &>(state["global1"]) == 5;
+}
+
+bool test_get_primitive_by_ref(sel::State & state) {
+    state.Load("../test/test.lua");
+    // This should not even compile, should it?
+    return static_cast<int &>(state["global1"]) == 5;
+}
+
+bool test_call_with_primitive_by_value(sel::State & state) {
+    bool success = false;
+    auto const accept_int_by_value = [&success](int x) {success = x == 5;};
+    state["test"] = accept_int_by_value;
+    state["test"](5);
+    return success;
+}
+
+bool test_call_with_primitive_by_const_ref(sel::State & state) {
+    bool success = false;
+    auto const accept_int_by_const_ref =
+        [&success](const int & x) {success = x == 5;};
+    state["test"] = accept_int_by_const_ref;
+    state["test"](5);
+    return success;
+}

--- a/test/interop_tests.h
+++ b/test/interop_tests.h
@@ -183,19 +183,12 @@ bool test_get_primitive_by_value(sel::State & state) {
 
 bool test_get_primitive_by_const_ref(sel::State & state) {
     state.Load("../test/test.lua");
-    // Crashes
     return static_cast<const int &>(state["global1"]) == 5;
 }
 
 bool test_get_primitive_by_rvalue_ref(sel::State & state) {
     state.Load("../test/test.lua");
     return static_cast<int &&>(state["global1"]) == 5;
-}
-
-bool test_get_primitive_by_ref(sel::State & state) {
-    state.Load("../test/test.lua");
-    // This should not even compile.
-    return static_cast<int &>(state["global1"]) == 5;
 }
 
 bool test_call_with_primitive_by_value(sel::State & state) {


### PR DESCRIPTION
I was trying to register a function with the signature "void(const std::string &)". Calling that lead to crashes, wrapping the function in "void(std::string)" works fine.

Trying different variants of references results in these tests. Inline comments state the problems I see.

A first quess what might be a solution is:
 1. Conditionally disable template<typename T> sel::Selector::operator T&() for primitive types. That would favour the already existing overloads for primitive types.
 1. Before getting function parameters from Luas stack, std::decay them for primitive types.