### PR TITLE
Enable use of exceptions

### DIFF
--- a/include/selene/BaseFun.h
+++ b/include/selene/BaseFun.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "exotics.h"
+#include <exception>
 #include <functional>
 #include <tuple>
 
@@ -14,7 +15,14 @@ namespace detail {
 
 inline int _lua_dispatcher(lua_State *l) {
     BaseFun *fun = (BaseFun *)lua_touserdata(l, lua_upvalueindex(1));
-    return fun->Apply(l);
+    try {
+        return fun->Apply(l);
+    } catch (std::exception & e) {
+        lua_pushstring(l, e.what());
+    } catch (...) {
+        lua_pushliteral(l, "Caught unknown exception.");
+    }
+    lua_error(l);
 }
 
 template <typename Ret, typename... Args, std::size_t... N>

--- a/include/selene/BaseFun.h
+++ b/include/selene/BaseFun.h
@@ -2,8 +2,10 @@
 
 #include "exotics.h"
 #include <exception>
+#include "exception.h"
 #include <functional>
 #include <tuple>
+#include "util.h"
 
 namespace sel {
 struct BaseFun {
@@ -19,10 +21,14 @@ inline int _lua_dispatcher(lua_State *l) {
         return fun->Apply(l);
     } catch (std::exception & e) {
         lua_pushstring(l, e.what());
+        Traceback(l);
+        store_current_exception(l, lua_tostring(l, -1));
     } catch (...) {
-        lua_pushliteral(l, "Caught unknown exception.");
+        lua_pushliteral(l, "<Unknown exception>");
+        Traceback(l);
+        store_current_exception(l, lua_tostring(l, -1));
     }
-    lua_error(l);
+    return lua_error(l);
 }
 
 template <typename Ret, typename... Args, std::size_t... N>

--- a/include/selene/Obj.h
+++ b/include/selene/Obj.h
@@ -3,7 +3,6 @@
 #include "ObjFun.h"
 #include <functional>
 #include <memory>
-#include "State.h"
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/selene/Registry.h
+++ b/include/selene/Registry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Class.h"
+#include "exception.h"
 #include "exotics.h"
 #include "Fun.h"
 #include "Obj.h"
@@ -22,7 +23,7 @@ private:
     std::vector<std::unique_ptr<BaseFun>> _funs;
     std::vector<std::unique_ptr<BaseObj>> _objs;
     std::vector<std::unique_ptr<BaseClass>> _classes;
-    std::function<void(int, std::string)> _exception_handler;
+    exception_handler _exception_handler;
     lua_State *_state;
 public:
     Registry(lua_State *state) : _state(state) {}
@@ -80,13 +81,13 @@ public:
         _classes.push_back(std::move(tmp));
     }
 
-    void SetExceptionHandler(std::function<void(int,std::string)> exception_handler) {
-        _exception_handler = std::move(exception_handler);
+    void SetExceptionHandler(exception_handler handler) {
+        _exception_handler = std::move(handler);
     }
 
-    void HandleException(int luaStatusCode, std::string message) const {
+    void HandleException(int luaStatusCode, std::string message, std::exception_ptr exception) const {
         if(_exception_handler) {
-            _exception_handler(luaStatusCode, std::move(message));
+            _exception_handler(luaStatusCode, std::move(message), std::move(exception));
         }
     }
 };

--- a/include/selene/Registry.h
+++ b/include/selene/Registry.h
@@ -81,11 +81,11 @@ public:
         _classes.push_back(std::move(tmp));
     }
 
-    void SetExceptionHandler(exception_handler handler) {
+    void SetExceptionHandler(exception_handler && handler) {
         _exception_handler = std::move(handler);
     }
 
-    void HandleException(int luaStatusCode, std::string message, std::exception_ptr exception) const {
+    void HandleException(int luaStatusCode, std::string message, std::exception_ptr exception = nullptr) const {
         if(_exception_handler) {
             _exception_handler(luaStatusCode, std::move(message), std::move(exception));
         }

--- a/include/selene/Registry.h
+++ b/include/selene/Registry.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Class.h"
-#include "exception.h"
 #include "exotics.h"
 #include "Fun.h"
 #include "Obj.h"
@@ -23,7 +22,6 @@ private:
     std::vector<std::unique_ptr<BaseFun>> _funs;
     std::vector<std::unique_ptr<BaseObj>> _objs;
     std::vector<std::unique_ptr<BaseClass>> _classes;
-    exception_handler _exception_handler;
     lua_State *_state;
 public:
     Registry(lua_State *state) : _state(state) {}
@@ -79,16 +77,6 @@ public:
             new Class<T, Ctor<T, CtorArgs...>, Funs...>
             {_state, _metatables, name, funs...});
         _classes.push_back(std::move(tmp));
-    }
-
-    void SetExceptionHandler(exception_handler && handler) {
-        _exception_handler = std::move(handler);
-    }
-
-    void HandleException(int luaStatusCode, std::string message, std::exception_ptr exception = nullptr) const {
-        if(_exception_handler) {
-            _exception_handler(luaStatusCode, std::move(message), std::move(exception));
-        }
     }
 };
 }

--- a/include/selene/Registry.h
+++ b/include/selene/Registry.h
@@ -22,6 +22,7 @@ private:
     std::vector<std::unique_ptr<BaseFun>> _funs;
     std::vector<std::unique_ptr<BaseObj>> _objs;
     std::vector<std::unique_ptr<BaseClass>> _classes;
+    std::function<void(int, std::string)> _exception_handler;
     lua_State *_state;
 public:
     Registry(lua_State *state) : _state(state) {}
@@ -77,6 +78,16 @@ public:
             new Class<T, Ctor<T, CtorArgs...>, Funs...>
             {_state, _metatables, name, funs...});
         _classes.push_back(std::move(tmp));
+    }
+
+    void SetExceptionHandler(std::function<void(int,std::string)> exception_handler) {
+        _exception_handler = std::move(exception_handler);
+    }
+
+    void HandleException(int luaStatusCode, std::string message) const {
+        if(_exception_handler) {
+            _exception_handler(luaStatusCode, std::move(message));
+        }
     }
 };
 }

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -176,17 +176,7 @@ public:
             lua_remove(state, handler_index - 1);
 
             if (statusCode != LUA_OK) {
-                stored_exception * stored = test_stored_exception(state);
-                if(stored) {
-                    eh.Handle(
-                        statusCode,
-                        stored->what,
-                        stored->exception);
-                } else {
-                    eh.Handle(
-                        statusCode,
-                        detail::_pop(detail::_id<std::string>(), state));
-                }
+                eh.Handle_top_of_stack(statusCode, state);
             }
         };
         return copy;

--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "exception.h"
 #include <iostream>
 #include <memory>
 #include <string>
@@ -94,11 +95,11 @@ public:
     }
 
     void HandleExceptionsPrintingToStdOut() {
-        _registry->SetExceptionHandler([](int, std::string msg){_print(msg);});
+        _registry->SetExceptionHandler([](int, std::string msg, std::exception_ptr){_print(msg);});
     }
 
-    void HandleExceptionsWith(std::function<void(int,std::string)> exception_handler) {
-        _registry->SetExceptionHandler(std::move(exception_handler));
+    void HandleExceptionsWith(exception_handler handler) {
+        _registry->SetExceptionHandler(std::move(handler));
     }
 
     void Push() {} // Base case

--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -23,9 +23,11 @@ public:
         if (_l == nullptr) throw 0;
         if (should_open_libs) luaL_openlibs(_l);
         _registry.reset(new Registry(_l));
+        HandleExceptionsPrintingToStdOut();
     }
     State(lua_State *l) : _l(l), _l_owner(false) {
         _registry.reset(new Registry(_l));
+        HandleExceptionsPrintingToStdOut();
     }
     State(const State &other) = delete;
     State &operator=(const State &other) = delete;
@@ -89,6 +91,14 @@ public:
         lua_pushstring(_l, modname.c_str());
         lua_call(_l, 1, 0);
 #endif
+    }
+
+    void HandleExceptionsPrintingToStdOut() {
+        _registry->SetExceptionHandler([](int, std::string msg){_print(msg);});
+    }
+
+    void HandleExceptionsWith(std::function<void(int,std::string)> exception_handler) {
+        _registry->SetExceptionHandler(std::move(exception_handler));
     }
 
     void Push() {} // Base case

--- a/include/selene/exception.h
+++ b/include/selene/exception.h
@@ -1,0 +1,85 @@
+#pragma once
+#include <functional>
+#include "primitives.h"
+#include <string>
+
+extern "C" {
+#include <lua.h>
+#include <lauxlib.h>
+}
+
+namespace sel {
+
+using exception_handler = std::function<void(int,std::string,std::exception_ptr)>;
+
+struct stored_exception {
+    std::string what;
+    std::exception_ptr exception;
+};
+
+inline std::string const * _stored_exception_metatable_name() {
+    static std::string const name = "selene_stored_exception";
+    return &name;
+}
+
+inline int _delete_stored_exception(lua_State * l) {
+    void * user_data = lua_touserdata(l, -1);
+    static_cast<stored_exception *>(user_data)->~stored_exception();
+    return 0;
+}
+
+inline int _push_stored_exceptions_what(lua_State * l) {
+    void * user_data = lua_touserdata(l, -1);
+    std::string const & what = static_cast<stored_exception *>(user_data)->what;
+    detail::_push(l, what);
+    return 1;
+}
+
+inline void _register_stored_exception_metatable(lua_State * l) {
+    luaL_newmetatable(l, _stored_exception_metatable_name()->c_str());
+    lua_pushcfunction(l, _delete_stored_exception);
+    lua_setfield(l, -2, "__gc");
+    lua_pushcclosure(l, _push_stored_exceptions_what, 0);
+    lua_setfield(l, -2, "__tostring");
+}
+
+inline void store_current_exception(lua_State * l, char const * what) {
+    void * user_data = lua_newuserdata(l, sizeof(stored_exception));
+    new(user_data) stored_exception{what, std::current_exception()};
+
+    if(LUA_TNIL == luaL_getmetatable(l, _stored_exception_metatable_name()->c_str())) {
+        lua_settop(l, -2);
+        _register_stored_exception_metatable(l);
+    }
+
+    lua_setmetatable(l, -2);
+}
+
+inline stored_exception * test_stored_exception(lua_State *l) {
+    if(lua_isuserdata(l, -1)) {
+        void * user_data = luaL_testudata(l, -1, _stored_exception_metatable_name()->c_str());
+        if(user_data != nullptr) {
+            return static_cast<stored_exception *>(user_data);
+        }
+    }
+    return nullptr;
+}
+
+inline bool push_stored_exceptions_what(lua_State * l) {
+    stored_exception * stored = test_stored_exception(l);
+    if(stored != nullptr) {
+        detail::_push(l, static_cast<const std::string &>(stored->what));
+        return true;
+    }
+    return false;
+}
+
+inline std::exception_ptr extract_stored_exception(lua_State *l) {
+    stored_exception * stored = test_stored_exception(l);
+    if(stored != nullptr) {
+        return stored->exception;
+    }
+    return nullptr;
+}
+
+}

--- a/include/selene/exception.h
+++ b/include/selene/exception.h
@@ -10,8 +10,6 @@ extern "C" {
 
 namespace sel {
 
-using exception_handler = std::function<void(int,std::string,std::exception_ptr)>;
-
 struct stored_exception {
     std::string what;
     std::exception_ptr exception;
@@ -82,5 +80,25 @@ inline std::exception_ptr extract_stored_exception(lua_State *l) {
     }
     return nullptr;
 }
+
+class ExceptionHandler {
+public:
+    using function = std::function<void(int,std::string,std::exception_ptr)>;
+
+private:
+    function _handler;
+
+public:
+    ExceptionHandler() = default;
+
+    explicit ExceptionHandler(function && handler) : _handler(handler) {}
+
+    void Handle(int luaStatusCode, std::string message, std::exception_ptr exception = nullptr) const {
+        if(_handler) {
+            _handler(luaStatusCode, std::move(message), std::move(exception));
+        }
+    }
+
+};
 
 }

--- a/include/selene/exception.h
+++ b/include/selene/exception.h
@@ -93,13 +93,13 @@ public:
 
     explicit ExceptionHandler(function && handler) : _handler(handler) {}
 
-    void Handle(int luaStatusCode, std::string message, std::exception_ptr exception = nullptr) const {
+    void Handle(int luaStatusCode, std::string message, std::exception_ptr exception = nullptr) {
         if(_handler) {
             _handler(luaStatusCode, std::move(message), std::move(exception));
         }
     }
 
-    void Handle_top_of_stack(int luaStatusCode, lua_State *L) const {
+    void Handle_top_of_stack(int luaStatusCode, lua_State *L) {
         stored_exception * stored = test_stored_exception(L);
         if(stored) {
             Handle(

--- a/include/selene/exception.h
+++ b/include/selene/exception.h
@@ -99,6 +99,20 @@ public:
         }
     }
 
+    void Handle_top_of_stack(int luaStatusCode, lua_State *L) const {
+        stored_exception * stored = test_stored_exception(L);
+        if(stored) {
+            Handle(
+                luaStatusCode,
+                stored->what,
+                stored->exception);
+        } else {
+            Handle(
+                luaStatusCode,
+                detail::_pop(detail::_id<std::string>(), L));
+        }
+    }
+
 };
 
 }

--- a/include/selene/exception.h
+++ b/include/selene/exception.h
@@ -47,7 +47,8 @@ inline void store_current_exception(lua_State * l, char const * what) {
     void * user_data = lua_newuserdata(l, sizeof(stored_exception));
     new(user_data) stored_exception{what, std::current_exception()};
 
-    if(LUA_TNIL == luaL_getmetatable(l, _stored_exception_metatable_name()->c_str())) {
+    luaL_getmetatable(l, _stored_exception_metatable_name()->c_str());
+    if(lua_isnil(l, -1)) {
         lua_settop(l, -2);
         _register_stored_exception_metatable(l);
     }

--- a/include/selene/function.h
+++ b/include/selene/function.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "exception.h"
 #include <functional>
 #include "LuaRef.h"
 #include <memory>
@@ -7,6 +8,9 @@
 #include "util.h"
 
 namespace sel {
+
+class Selector;
+
 /*
  * Similar to an std::function but refers to a lua function
  */
@@ -15,19 +19,30 @@ class function {};
 
 template <typename R, typename... Args>
 class function<R(Args...)> {
+    friend class Selector;
 private:
     LuaRef _ref;
     lua_State *_state;
+    ExceptionHandler *_exception_handler;
+
+    void _enable_exception_handler(ExceptionHandler *exception_handler) {
+        _exception_handler = exception_handler;
+    }
 public:
-    function(int ref, lua_State *state) : _ref(state, ref), _state(state) {}
+    function(int ref, lua_State *state) : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
 
     R operator()(Args... args) {
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
-        lua_pcall(_state, num_args, 1, handler_index);
+        const auto status = lua_pcall(_state, num_args, 1, handler_index);
         lua_remove(_state, handler_index);
+
+        if(status != LUA_OK && _exception_handler) {
+            _exception_handler->Handle_top_of_stack(status, _state);
+        }
+
         R ret = detail::_pop(detail::_id<R>{}, _state);
         lua_settop(_state, 0);
         return ret;
@@ -40,19 +55,30 @@ public:
 
 template <typename... Args>
 class function<void(Args...)> {
+    friend class Selector;
 private:
     LuaRef _ref;
     lua_State *_state;
+    ExceptionHandler *_exception_handler;
+
+    void _enable_exception_handler(ExceptionHandler *exception_handler) {
+        _exception_handler = exception_handler;
+    }
 public:
-    function(int ref, lua_State *state) : _ref(state, ref), _state(state) {}
+    function(int ref, lua_State *state) : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
 
     void operator()(Args... args) {
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
-        lua_pcall(_state, num_args, 1, handler_index);
+        const auto status = lua_pcall(_state, num_args, 1, handler_index);
         lua_remove(_state, handler_index);
+
+        if(status != LUA_OK && _exception_handler) {
+            _exception_handler->Handle_top_of_stack(status, _state);
+        }
+
         lua_settop(_state, 0);
     }
 
@@ -64,11 +90,17 @@ public:
 // Specialization for multireturn types
 template <typename... R, typename... Args>
 class function<std::tuple<R...>(Args...)> {
+    friend class Selector;
 private:
     LuaRef _ref;
     lua_State *_state;
+    ExceptionHandler *_exception_handler;
+
+    void _enable_exception_handler(ExceptionHandler *exception_handler) {
+        _exception_handler = exception_handler;
+    }
 public:
-    function(int ref, lua_State *state) : _ref(state, ref), _state(state) {}
+    function(int ref, lua_State *state) : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
 
     std::tuple<R...> operator()(Args... args) {
         int handler_index = SetErrorHandler(_state);
@@ -76,8 +108,13 @@ public:
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
         constexpr int num_ret = sizeof...(R);
-        lua_pcall(_state, num_args, num_ret, handler_index);
+        const auto status = lua_pcall(_state, num_args, num_ret, handler_index);
         lua_remove(_state, handler_index);
+
+        if(status != LUA_OK && _exception_handler) {
+            _exception_handler->Handle_top_of_stack(status, _state);
+        }
+
         return detail::_pop_n_reset<R...>(_state);
     }
 

--- a/include/selene/function.h
+++ b/include/selene/function.h
@@ -11,6 +11,34 @@ namespace sel {
 
 class Selector;
 
+namespace detail {
+struct function_base {
+    LuaRef _ref;
+    lua_State *_state;
+    ExceptionHandler *_exception_handler;
+
+    function_base(int ref, lua_State *state)
+        : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
+
+    void _enable_exception_handler(ExceptionHandler *exception_handler) {
+        _exception_handler = exception_handler;
+    }
+
+    void protected_call(int const num_args, int const num_ret,
+                        int const handler_index) {
+        const auto status = lua_pcall(_state, num_args, num_ret, handler_index);
+
+        if (status != LUA_OK && _exception_handler) {
+            _exception_handler->Handle_top_of_stack(status, _state);
+        }
+    }
+
+    void Push(lua_State *state) {
+        _ref.Push(state);
+    }
+};
+}
+
 /*
  * Similar to an std::function but refers to a lua function
  */
@@ -18,89 +46,55 @@ template <class>
 class function {};
 
 template <typename R, typename... Args>
-class function<R(Args...)> {
+class function<R(Args...)> : detail::function_base {
     friend class Selector;
-private:
-    LuaRef _ref;
-    lua_State *_state;
-    ExceptionHandler *_exception_handler;
-
-    void _enable_exception_handler(ExceptionHandler *exception_handler) {
-        _exception_handler = exception_handler;
-    }
 public:
-    function(int ref, lua_State *state) : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
+    using function_base::function_base;
 
     R operator()(Args... args) {
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
-        const auto status = lua_pcall(_state, num_args, 1, handler_index);
+
+        protected_call(num_args, 1, handler_index);
+
         lua_remove(_state, handler_index);
-
-        if(status != LUA_OK && _exception_handler) {
-            _exception_handler->Handle_top_of_stack(status, _state);
-        }
-
         R ret = detail::_pop(detail::_id<R>{}, _state);
         lua_settop(_state, 0);
         return ret;
     }
 
-    void Push(lua_State *state) {
-        _ref.Push(state);
-    }
+    using function_base::Push;
 };
 
 template <typename... Args>
-class function<void(Args...)> {
+class function<void(Args...)> : detail::function_base{
     friend class Selector;
-private:
-    LuaRef _ref;
-    lua_State *_state;
-    ExceptionHandler *_exception_handler;
-
-    void _enable_exception_handler(ExceptionHandler *exception_handler) {
-        _exception_handler = exception_handler;
-    }
 public:
-    function(int ref, lua_State *state) : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
+    using function_base::function_base;
 
     void operator()(Args... args) {
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
-        const auto status = lua_pcall(_state, num_args, 1, handler_index);
+
+        protected_call(num_args, 1, handler_index);
+
         lua_remove(_state, handler_index);
-
-        if(status != LUA_OK && _exception_handler) {
-            _exception_handler->Handle_top_of_stack(status, _state);
-        }
-
         lua_settop(_state, 0);
     }
 
-    void Push(lua_State *state) {
-        _ref.Push(state);
-    }
+    using function_base::Push;
 };
 
 // Specialization for multireturn types
 template <typename... R, typename... Args>
-class function<std::tuple<R...>(Args...)> {
+class function<std::tuple<R...>(Args...)> : detail::function_base{
     friend class Selector;
-private:
-    LuaRef _ref;
-    lua_State *_state;
-    ExceptionHandler *_exception_handler;
-
-    void _enable_exception_handler(ExceptionHandler *exception_handler) {
-        _exception_handler = exception_handler;
-    }
 public:
-    function(int ref, lua_State *state) : _ref(state, ref), _state(state), _exception_handler(nullptr) {}
+    using function_base::function_base;
 
     std::tuple<R...> operator()(Args... args) {
         int handler_index = SetErrorHandler(_state);
@@ -108,18 +102,13 @@ public:
         detail::_push_n(_state, args...);
         constexpr int num_args = sizeof...(Args);
         constexpr int num_ret = sizeof...(R);
-        const auto status = lua_pcall(_state, num_args, num_ret, handler_index);
+
+        protected_call(num_args, num_ret, handler_index);
+
         lua_remove(_state, handler_index);
-
-        if(status != LUA_OK && _exception_handler) {
-            _exception_handler->Handle_top_of_stack(status, _state);
-        }
-
         return detail::_pop_n_reset<R...>(_state);
     }
 
-    void Push(lua_State *state) {
-        _ref.Push(state);
-    }
+    using function_base::Push;
 };
 }

--- a/include/selene/util.h
+++ b/include/selene/util.h
@@ -70,7 +70,6 @@ inline int ErrorHandler(lua_State *L) {
         if (!msg)
             msg = "<error object>";
     }
-    _print(msg);
     return 1;
 }
 

--- a/include/selene/util.h
+++ b/include/selene/util.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "exception.h"
 #include <iostream>
 
 extern "C" {
@@ -55,22 +56,32 @@ inline bool check(lua_State *L, int code) {
     }
 }
 
-inline int ErrorHandler(lua_State *L) {
-    // call debug.traceback
-    lua_getglobal(L, "debug");
-    lua_getfield(L, -1, "traceback");
-    lua_pushvalue(L, 1);
-    lua_pushinteger(L, 2);
-    lua_call(L, 2, 1);
-
-    // _print(<error-message> + call stack)
+inline int Traceback(lua_State *L) {
+    // Make nil and values not convertible to string human readable.
     const char* msg = "<not set>";
     if (!lua_isnil(L, -1)) {
         msg = lua_tostring(L, -1);
         if (!msg)
             msg = "<error object>";
     }
+    lua_pushstring(L, msg);
+
+    // call debug.traceback
+    lua_getglobal(L, "debug");
+    lua_getfield(L, -1, "traceback");
+    lua_pushvalue(L, -3);
+    lua_pushinteger(L, 2);
+    lua_call(L, 2, 1);
+
     return 1;
+}
+
+inline int ErrorHandler(lua_State *L) {
+    if(test_stored_exception(L) != nullptr) {
+        return 1;
+    }
+
+    return Traceback(L);
 }
 
 inline int SetErrorHandler(lua_State *L) {

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -6,6 +6,7 @@
 #include "reference_tests.h"
 #include "selector_tests.h"
 #include "error_tests.h"
+#include "exception_tests.h"
 #include <map>
 
 // A very simple testing framework
@@ -19,6 +20,9 @@ static TestMap tests = {
     {"test_call_undefined_function", test_call_undefined_function},
     {"test_call_undefined_function2", test_call_undefined_function2},
     {"test_call_stackoverflow", test_call_stackoverflow},
+
+    {"test_catch_exception_from_callback_within_lua", test_catch_exception_from_callback_within_lua},
+    {"test_catch_unknwon_exception_from_callback_within_lua", test_catch_unknwon_exception_from_callback_within_lua},
 
     {"test_function_no_args", test_function_no_args},
     {"test_add", test_add},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -23,6 +23,8 @@ static TestMap tests = {
 
     {"test_catch_exception_from_callback_within_lua", test_catch_exception_from_callback_within_lua},
     {"test_catch_unknwon_exception_from_callback_within_lua", test_catch_unknwon_exception_from_callback_within_lua},
+    {"test_call_exception_handler", test_call_exception_handler},
+    {"test_call_exception_handler_for_exception_from_callback", test_call_exception_handler_for_exception_from_callback},
 
     {"test_function_no_args", test_function_no_args},
     {"test_add", test_add},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -23,8 +23,9 @@ static TestMap tests = {
 
     {"test_catch_exception_from_callback_within_lua", test_catch_exception_from_callback_within_lua},
     {"test_catch_unknwon_exception_from_callback_within_lua", test_catch_unknwon_exception_from_callback_within_lua},
-    {"test_call_exception_handler", test_call_exception_handler},
+    {"test_call_exception_handler_for_exception_from_lua", test_call_exception_handler_for_exception_from_lua},
     {"test_call_exception_handler_for_exception_from_callback", test_call_exception_handler_for_exception_from_callback},
+    {"test_rethrow_exception_for_exception_from_callback", test_rethrow_exception_for_exception_from_callback},
 
     {"test_function_no_args", test_function_no_args},
     {"test_add", test_add},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -25,6 +25,7 @@ static TestMap tests = {
     {"test_catch_unknwon_exception_from_callback_within_lua", test_catch_unknwon_exception_from_callback_within_lua},
     {"test_call_exception_handler_for_exception_from_lua", test_call_exception_handler_for_exception_from_lua},
     {"test_call_exception_handler_for_exception_from_callback", test_call_exception_handler_for_exception_from_callback},
+    {"test_call_exception_handler_while_using_sel_function", test_call_exception_handler_while_using_sel_function},
     {"test_rethrow_exception_for_exception_from_callback", test_rethrow_exception_for_exception_from_callback},
 
     {"test_function_no_args", test_function_no_args},

--- a/test/exception_tests.h
+++ b/test/exception_tests.h
@@ -49,6 +49,19 @@ bool test_call_exception_handler_for_exception_from_callback(sel::State &state) 
         && message.find("Message from C++.") != std::string::npos;
 }
 
+bool test_call_exception_handler_while_using_sel_function(sel::State &state) {
+    state.Load("../test/test_exceptions.lua");
+    int luaStatusCode = LUA_OK;
+    std::string message;
+    state.HandleExceptionsWith([&luaStatusCode, &message](int s, std::string msg, std::exception_ptr exception) {
+        luaStatusCode = s, message = std::move(msg);
+    });
+    sel::function<void(std::string)> raiseFromLua = state["raise"];
+    raiseFromLua("Message from Lua.");
+    return luaStatusCode == LUA_ERRRUN
+        && message.find("Message from Lua.") != std::string::npos;
+}
+
 bool test_rethrow_exception_for_exception_from_callback(sel::State &state) {
     state.HandleExceptionsWith([](int s, std::string msg, std::exception_ptr exception) {
         if(exception) {

--- a/test/exception_tests.h
+++ b/test/exception_tests.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <exception>
+#include <lua.h>
 #include <selene.h>
 
 bool test_catch_exception_from_callback_within_lua(sel::State &state) {
@@ -21,4 +22,29 @@ bool test_catch_unknwon_exception_from_callback_within_lua(sel::State &state) {
     std::string msg;
     sel::tie(ok, msg) = state["call_protected"]("throw_int");
     return !ok && msg == "Caught unknown exception.";
+}
+
+bool test_call_exception_handler(sel::State &state) {
+    state.Load("../test/test_exceptions.lua");
+    int luaStatusCode = LUA_OK;
+    std::string message;
+    state.HandleExceptionsWith([&luaStatusCode, &message](int s, std::string msg) {
+        luaStatusCode = s, message = std::move(msg);
+    });
+    state["raise"]("Arbitrary message.");
+    return luaStatusCode == LUA_ERRRUN
+        && message.find("Arbitrary message.") != std::string::npos;
+}
+
+bool test_call_exception_handler_for_exception_from_callback(sel::State &state) {
+    int luaStatusCode = LUA_OK;
+    std::string message;
+    state.HandleExceptionsWith([&luaStatusCode, &message](int s, std::string msg) {
+        luaStatusCode = s, message = std::move(msg);
+    });
+    state["throw_logic_error"] =
+        []() {throw std::logic_error("Arbitrary message.");};
+    state["throw_logic_error"]();
+    return luaStatusCode == LUA_ERRRUN
+        && message.find("Arbitrary message.") != std::string::npos;
 }

--- a/test/exception_tests.h
+++ b/test/exception_tests.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <exception>
+#include <selene.h>
+
+bool test_catch_exception_from_callback_within_lua(sel::State &state) {
+    state.Load("../test/test_exceptions.lua");
+    state["throw_logic_error"] =
+        []() {throw std::logic_error("Arbitrary message.");};
+    bool ok = true;
+    std::string msg;
+    sel::tie(ok, msg) = state["call_protected"]("throw_logic_error");
+    return !ok && msg == "Arbitrary message.";
+}
+
+bool test_catch_unknwon_exception_from_callback_within_lua(sel::State &state) {
+    state.Load("../test/test_exceptions.lua");
+    state["throw_int"] =
+        []() {throw 0;};
+    bool ok = true;
+    std::string msg;
+    sel::tie(ok, msg) = state["call_protected"]("throw_int");
+    return !ok && msg == "Caught unknown exception.";
+}

--- a/test/test_exceptions.lua
+++ b/test/test_exceptions.lua
@@ -1,0 +1,3 @@
+function call_protected(function_name)
+   return pcall(_ENV[function_name])
+end

--- a/test/test_exceptions.lua
+++ b/test/test_exceptions.lua
@@ -1,3 +1,7 @@
 function call_protected(function_name)
    return pcall(_ENV[function_name])
 end
+
+function raise(exception_message)
+   error(exception_message)
+end

--- a/test/test_exceptions.lua
+++ b/test/test_exceptions.lua
@@ -1,5 +1,6 @@
 function call_protected(function_name)
-   return pcall(_ENV[function_name])
+   ok, msg = pcall(_ENV[function_name])
+   return ok, tostring(msg)
 end
 
 function raise(exception_message)


### PR DESCRIPTION
Add support for the following use cases:
 1. Callbacks throw exceptions, Lua scripts can catch them using `ok, result = pcall(possibly_throwing_function)` and get the C++-exception's `what()` message by applying `tostring(result)` to the error object.
 2. Not handled exceptions raised in Lua scripts by calling `error("...")` are delivered to a user providable exception handler, defaulting to output to `std::cout`.
 3. Exceptions thrown in callbacks, propagate cleanly through the Lua script and are delivered to a user providable exception handler as rethrowable `std::exception_ptr`.

I did not make the support for exceptions optional through a compiletime-switch because:
 1. users who do neither use exceptions nor call `error` from within Lua scripts shoud see no runtime overhead.
 2. users wo call `error` from within Lua scripts are only paying one check that the error message is not `LUA_TUSERDATA`

This solves #95 for me.