### PR TITLE
Use resource handles

### DIFF
--- a/include/selene/ResourceHandler.h
+++ b/include/selene/ResourceHandler.h
@@ -25,4 +25,25 @@ public:
     }
 };
 
+class ResetStackOnScopeExit {
+    lua_State * _stack;
+    int _saved_top_index;
+
+public:
+    explicit ResetStackOnScopeExit(lua_State * stack)
+    : _stack(stack)
+    , _saved_top_index(lua_gettop(_stack))
+    {}
+
+    ~ResetStackOnScopeExit() {
+        if(_stack) {
+            lua_settop(_stack, _saved_top_index);
+        }
+    }
+
+    ResetStackOnScopeExit(ResetStackOnScopeExit const & ) = delete;
+    ResetStackOnScopeExit(ResetStackOnScopeExit       &&) = delete;
+    ResetStackOnScopeExit & operator=(ResetStackOnScopeExit const & ) = delete;
+    ResetStackOnScopeExit & operator=(ResetStackOnScopeExit       &&) = delete;
+};
 }

--- a/include/selene/ResourceHandler.h
+++ b/include/selene/ResourceHandler.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace sel {
+
+template<typename Signature>
+class CallOnce;
+
+template<typename... Args>
+class CallOnce<void(Args...)> {
+    std::function<void(Args...)> _f;
+public:
+    CallOnce() = default;
+
+    CallOnce(std::function<void(Args...)> f) : _f(std::move(f)) {}
+
+    void operator()(Args... args) {
+        if(*this) {
+            auto consume_f = std::move(_f);
+            consume_f(std::forward<Args>(args)...);
+        }
+    }
+
+    operator bool() const {
+        return static_cast<bool>(_f);
+    }
+};
+
+}

--- a/include/selene/ResourceHandler.h
+++ b/include/selene/ResourceHandler.h
@@ -14,7 +14,7 @@ public:
     CallOnce(std::function<void(Args...)> f) : _f(std::move(f)) {}
 
     void operator()(Args... args) {
-        if(*this) {
+        if (_f) {
             auto consume_f = std::move(_f);
             consume_f(std::forward<Args>(args)...);
         }
@@ -31,16 +31,12 @@ class ResetStackOnScopeExit {
 
 public:
     explicit ResetStackOnScopeExit(lua_State * stack)
-    : _stack(stack)
-    , _saved_top_index(lua_gettop(_stack))
+        : _stack(stack),
+          _saved_top_index(lua_gettop(_stack))
     {}
 
-    void KeepChanges() {
-        _stack = nullptr;
-    }
-
     ~ResetStackOnScopeExit() {
-        if(_stack) {
+        if (_stack) {
             lua_settop(_stack, _saved_top_index);
         }
     }

--- a/include/selene/ResourceHandler.h
+++ b/include/selene/ResourceHandler.h
@@ -35,6 +35,10 @@ public:
     , _saved_top_index(lua_gettop(_stack))
     {}
 
+    void KeepChanges() {
+        _stack = nullptr;
+    }
+
     ~ResetStackOnScopeExit() {
         if(_stack) {
             lua_settop(_stack, _saved_top_index);

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -103,6 +103,12 @@ private:
         _traverse();
         _put(std::move(push));
     }
+
+    void _evaluate_retrieve(int num_results) const {
+        _traverse();
+        _get();
+        _functor(num_results);
+    }
 public:
 
     Selector(const Selector &other)
@@ -263,9 +269,7 @@ public:
     template <typename... Ret>
     std::tuple<Ret...> GetTuple() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(sizeof...(Ret));
+        _evaluate_retrieve(sizeof...(Ret));
         return detail::_get_n<Ret...>(_state);
     }
 
@@ -277,67 +281,51 @@ public:
     >
     operator T&() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return *detail::_pop(detail::_id<T*>{}, _state);
     }
 
     template <typename T>
     operator T*() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<T*>{}, _state);
     }
 
     operator bool() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<bool>{}, _state);
     }
 
     operator int() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<int>{}, _state);
     }
 
     operator unsigned int() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<unsigned int>{}, _state);
     }
 
     operator lua_Number() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<lua_Number>{}, _state);
     }
 
     operator std::string() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<std::string>{}, _state);
     }
 
     template <typename R, typename... Args>
     operator sel::function<R(Args...)>() {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         auto ret = detail::_pop(detail::_id<sel::function<R(Args...)>>{},
                                 _state);
         ret._enable_exception_handler(_exception_handler);
@@ -430,9 +418,7 @@ public:
 private:
     std::string ToString() const {
         ResetStackOnScopeExit save(_state);
-        _traverse();
-        _get();
-        _functor(1);
+        _evaluate_retrieve(1);
         return detail::_pop(detail::_id<std::string>{}, _state);
     }
 };

--- a/include/selene/exception.h
+++ b/include/selene/exception.h
@@ -109,7 +109,7 @@ public:
         } else {
             Handle(
                 luaStatusCode,
-                detail::_pop(detail::_id<std::string>(), L));
+                detail::_get(detail::_id<std::string>(), L, -1));
         }
     }
 

--- a/include/selene/function.h
+++ b/include/selene/function.h
@@ -62,9 +62,7 @@ public:
 
         protected_call(num_args, 1, handler_index);
 
-        lua_remove(_state, handler_index);
-        R ret = detail::_pop(detail::_id<R>{}, _state);
-        return ret;
+        return detail::_get(detail::_id<R>{}, _state, -1);
     }
 
     using function_base::Push;
@@ -85,8 +83,6 @@ public:
         constexpr int num_args = sizeof...(Args);
 
         protected_call(num_args, 1, handler_index);
-
-        lua_remove(_state, handler_index);
     }
 
     using function_base::Push;
@@ -111,7 +107,7 @@ public:
         protected_call(num_args, num_ret, handler_index);
 
         lua_remove(_state, handler_index);
-        return detail::_pop_n_reset<R...>(_state);
+        return detail::_get_n<R...>(_state);
     }
 
     using function_base::Push;

--- a/include/selene/function.h
+++ b/include/selene/function.h
@@ -5,6 +5,7 @@
 #include "LuaRef.h"
 #include <memory>
 #include "primitives.h"
+#include "ResourceHandler.h"
 #include "util.h"
 
 namespace sel {
@@ -52,6 +53,8 @@ public:
     using function_base::function_base;
 
     R operator()(Args... args) {
+        ResetStackOnScopeExit save(_state);
+
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
@@ -61,7 +64,6 @@ public:
 
         lua_remove(_state, handler_index);
         R ret = detail::_pop(detail::_id<R>{}, _state);
-        lua_settop(_state, 0);
         return ret;
     }
 
@@ -75,6 +77,8 @@ public:
     using function_base::function_base;
 
     void operator()(Args... args) {
+        ResetStackOnScopeExit save(_state);
+
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);
@@ -83,7 +87,6 @@ public:
         protected_call(num_args, 1, handler_index);
 
         lua_remove(_state, handler_index);
-        lua_settop(_state, 0);
     }
 
     using function_base::Push;
@@ -97,6 +100,8 @@ public:
     using function_base::function_base;
 
     std::tuple<R...> operator()(Args... args) {
+        ResetStackOnScopeExit save(_state);
+
         int handler_index = SetErrorHandler(_state);
         _ref.Push(_state);
         detail::_push_n(_state, args...);

--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -172,21 +172,6 @@ typename _get_n_impl<T...>::type _get_n(lua_State *l) {
     return _get_n_impl<T...>::apply(l);
 }
 
-template <typename... T>
-typename _get_n_impl<T...>::type _pop_n(lua_State *l) {
-    auto ret = _get_n<T...>(l);
-    lua_pop(l, sizeof...(T));
-    return ret;
-}
-
-template <typename... T>
-typename _get_n_impl<T...>::type
-_pop_n_reset(lua_State *l) {
-    auto ret = _get_n<T...>(l);
-    lua_settop(l, 0);
-    return ret;
-}
-
 template <typename T>
 T _pop(_id<T> t, lua_State *l) {
     T ret =  _get(t, l, -1);

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -27,6 +27,7 @@ static TestMap tests = {
     {"test_call_exception_handler_for_exception_from_callback", test_call_exception_handler_for_exception_from_callback},
     {"test_call_exception_handler_while_using_sel_function", test_call_exception_handler_while_using_sel_function},
     {"test_rethrow_exception_for_exception_from_callback", test_rethrow_exception_for_exception_from_callback},
+    {"test_rethrow_using_sel_function", test_rethrow_using_sel_function},
 
     {"test_function_no_args", test_function_no_args},
     {"test_add", test_add},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -17,6 +17,7 @@ using TestMap = std::map<const char *, Test>;
 static TestMap tests = {
     {"test_load_error", test_load_error},
     {"test_load_syntax_error", test_load_syntax_error},
+    {"test_do_syntax_error", test_do_syntax_error},
     {"test_call_undefined_function", test_call_undefined_function},
     {"test_call_undefined_function2", test_call_undefined_function2},
     {"test_call_stackoverflow", test_call_stackoverflow},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -29,6 +29,7 @@ static TestMap tests = {
     {"test_call_exception_handler_while_using_sel_function", test_call_exception_handler_while_using_sel_function},
     {"test_rethrow_exception_for_exception_from_callback", test_rethrow_exception_for_exception_from_callback},
     {"test_rethrow_using_sel_function", test_rethrow_using_sel_function},
+    {"test_throw_on_exception_using_Load", test_throw_on_exception_using_Load},
 
     {"test_function_no_args", test_function_no_args},
     {"test_add", test_add},

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -31,6 +31,7 @@ static TestMap tests = {
     {"test_function_no_args", test_function_no_args},
     {"test_add", test_add},
     {"test_multi_return", test_multi_return},
+    {"test_multi_return_invoked_once", test_multi_return_invoked_once},
     {"test_heterogeneous_return", test_heterogeneous_return},
     {"test_call_field", test_call_field},
     {"test_call_c_function", test_call_c_function},

--- a/test/error_tests.h
+++ b/test/error_tests.h
@@ -39,6 +39,13 @@ bool test_load_syntax_error(sel::State &state) {
         && capture.Content().find(expected) != std::string::npos;
 }
 
+bool test_do_syntax_error(sel::State &state) {
+    const char* expected = "unexpected symbol";
+    CapturedStdout capture;
+    return !state("function syntax_error() 1 2 3 4 end")
+        && capture.Content().find(expected) != std::string::npos;
+}
+
 bool test_call_undefined_function(sel::State &state) {
     state.Load("../test/test_error.lua");
     const char* expected = "attempt to call a nil value";

--- a/test/exception_tests.h
+++ b/test/exception_tests.h
@@ -77,3 +77,20 @@ bool test_rethrow_exception_for_exception_from_callback(sel::State &state) {
     }
     return false;
 }
+
+bool test_rethrow_using_sel_function(sel::State & state) {
+    state.HandleExceptionsWith([](int s, std::string msg, std::exception_ptr exception) {
+        if(exception) {
+            std::rethrow_exception(exception);
+        }
+    });
+    state["throw_logic_error"] =
+        []() {throw std::logic_error("Arbitrary message.");};
+    sel::function<void(void)> cause_exception = state["throw_logic_error"];
+    try {
+        cause_exception();
+    } catch(std::logic_error & e) {
+        return std::string(e.what()).find("Arbitrary message.") != std::string::npos;
+    }
+    return false;
+}

--- a/test/exception_tests.h
+++ b/test/exception_tests.h
@@ -94,3 +94,15 @@ bool test_rethrow_using_sel_function(sel::State & state) {
     }
     return false;
 }
+
+bool test_throw_on_exception_using_Load(sel::State &state) {
+    state.HandleExceptionsWith([](int s, std::string msg, std::exception_ptr exception) {
+        throw std::logic_error(msg);
+    });
+    try {
+        state.Load("non_existing_file");
+    } catch (std::logic_error & e) {
+        return std::string(e.what()).find("non_existing_file") != std::string::npos;
+    }
+    return false;
+}

--- a/test/interop_tests.h
+++ b/test/interop_tests.h
@@ -28,6 +28,17 @@ bool test_multi_return(sel::State &state) {
     return (sum == 4 && difference == 2);
 }
 
+bool test_multi_return_invoked_once(sel::State &state) {
+    int invocation_count = 0;
+    state["two_ints"] = [&invocation_count](){
+        ++invocation_count;
+        return std::tuple<int, int>{1, 2};
+    };
+    int res_a = 0, res_b = 0;
+    sel::tie(res_a, res_b) = state["two_ints"]();
+    return invocation_count == 1;
+}
+
 bool test_heterogeneous_return(sel::State &state) {
     state.Load("../test/test.lua");
     int x;


### PR DESCRIPTION
I think the library benefits from further use of resource handles (RAII).

 - [x] Encapsulate in a type the concept of calling exactly once to Lua for statements like `Res r = state["lua_function"](...)`.
 - [x] Use the destructor of a type to clear the stack (`lua_State`) after modifying activities.
