### PR TITLE
Lessen use of std function

### DIFF
--- a/include/selene/LuaRef.h
+++ b/include/selene/LuaRef.h
@@ -28,8 +28,18 @@ public:
     LuaRef(lua_State *state, int ref)
         : _ref(new int{ref}, detail::LuaRefDeleter{state}) {}
 
-    void Push(lua_State *state) {
+    void Push(lua_State *state) const {
         lua_rawgeti(state, LUA_REGISTRYINDEX, *_ref);
     }
 };
+
+LuaRef make_Ref(lua_State *state, const std::string & name) {
+    lua_pushstring(state, name.c_str());
+    return LuaRef(state, luaL_ref(state, LUA_REGISTRYINDEX));
+}
+
+LuaRef make_Ref(lua_State *state, int index) {
+    lua_pushinteger(state, index);
+    return LuaRef(state, luaL_ref(state, LUA_REGISTRYINDEX));
+}
 }

--- a/include/selene/ResourceHandler.h
+++ b/include/selene/ResourceHandler.h
@@ -2,21 +2,19 @@
 
 namespace sel {
 
-template<typename Signature>
-class CallOnce;
-
-template<typename... Args>
-class CallOnce<void(Args...)> {
-    std::function<void(Args...)> _f;
+template<typename Class, typename... Args>
+class CallOnceMemFun {
+    void (Class::*_f)(Args...) const = nullptr;
 public:
-    CallOnce() = default;
+    CallOnceMemFun() = default;
 
-    CallOnce(std::function<void(Args...)> f) : _f(std::move(f)) {}
+    CallOnceMemFun(void (Class::*f)(Args...) const) : _f(f) {}
 
-    void operator()(Args... args) {
+    void operator()(Class const & obj, Args... args) {
         if (_f) {
-            auto consume_f = std::move(_f);
-            consume_f(std::forward<Args>(args)...);
+            auto consume_f = _f;
+            _f = nullptr;
+            (obj.*consume_f)(std::forward<Args>(args)...);
         }
     }
 

--- a/include/selene/ResourceHandler.h
+++ b/include/selene/ResourceHandler.h
@@ -2,24 +2,34 @@
 
 namespace sel {
 
-template<typename Class, typename... Args>
-class CallOnceMemFun {
-    void (Class::*_f)(Args...) const = nullptr;
+class MovingFlag {
+    bool flag = false;
+
 public:
-    CallOnceMemFun() = default;
+    MovingFlag() = default;
 
-    CallOnceMemFun(void (Class::*f)(Args...) const) : _f(f) {}
+    MovingFlag(MovingFlag const &) = default;
 
-    void operator()(Class const & obj, Args... args) {
-        if (_f) {
-            auto consume_f = _f;
-            _f = nullptr;
-            (obj.*consume_f)(std::forward<Args>(args)...);
-        }
+    MovingFlag & operator=(MovingFlag const &) = default;
+
+    MovingFlag(MovingFlag && that) noexcept
+        : flag(that.flag) {
+        that = false;
+    }
+
+    MovingFlag & operator=(MovingFlag && that) noexcept {
+        this->flag = that.flag;
+        that = false;
+        return *this;
     }
 
     operator bool() const {
-        return static_cast<bool>(_f);
+        return flag;
+    }
+
+    MovingFlag & operator=(bool x) {
+        flag = x;
+        return *this;
     }
 };
 

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -56,7 +56,7 @@ private:
     std::vector<LuaRef> _functor_arguments;
     // Functor is stored when the () operator is invoked. The argument
     // is used to indicate how many return values are expected
-    mutable CallOnce<void(Selector const &, int)> _functor;
+    mutable CallOnceMemFun<Selector, int> _functor;
 
     Selector(lua_State *s, Registry &r, ExceptionHandler &eh, const std::string &name,
              std::vector<LuaRef> traversal, LuaRef key)
@@ -122,32 +122,32 @@ private:
         _functor(*this, num_results);
     }
 
-    static void _evaluate_function_call(Selector const & self, int num_ret) {
+    void _evaluate_function_call(int num_ret) const {
         // install handler, and swap(handler, function) on lua stack
-        int handler_index = SetErrorHandler(self._state);
+        int handler_index = SetErrorHandler(_state);
         int func_index = handler_index - 1;
 #if LUA_VERSION_NUM >= 502
-        lua_pushvalue(self._state, func_index);
-        lua_copy(self._state, handler_index, func_index);
-        lua_replace(self._state, handler_index);
+        lua_pushvalue(_state, func_index);
+        lua_copy(_state, handler_index, func_index);
+        lua_replace(_state, handler_index);
 #else
-        lua_pushvalue(self._state, func_index);
-        lua_push_value(self._state, handler_index);
-        lua_replace(self._state, func_index);
-        lua_replace(self._state, handler_index);
+        lua_pushvalue(_state, func_index);
+        lua_push_value(_state, handler_index);
+        lua_replace(_state, func_index);
+        lua_replace(_state, handler_index);
 #endif
         // call lua function with error handler
-        for(auto const & arg : self._functor_arguments) {
-            arg.Push(self._state);
+        for(auto const & arg : _functor_arguments) {
+            arg.Push(_state);
         }
         auto const statusCode =
-            lua_pcall(self._state, self._functor_arguments.size(), num_ret, handler_index - 1);
+            lua_pcall(_state, _functor_arguments.size(), num_ret, handler_index - 1);
 
         // remove error handler
-        lua_remove(self._state, handler_index - 1);
+        lua_remove(_state, handler_index - 1);
 
         if (statusCode != LUA_OK) {
-            self._exception_handler->Handle_top_of_stack(statusCode, self._state);
+            _exception_handler->Handle_top_of_stack(statusCode, _state);
         }
     }
 public:
@@ -185,7 +185,7 @@ public:
         Selector copy{*this};
         const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
         const auto eh = _exception_handler;
-        copy._functor = CallOnce<void(Selector const &, int)>{_evaluate_function_call};
+        copy._functor = CallOnceMemFun<Selector, int>{&Selector::_evaluate_function_call};
         copy._functor_arguments = make_Refs(_state, std::forward<Args>(args)...);
         return copy;
     }

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -71,12 +71,14 @@ private:
         const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
         // `name' is passed by value because lambda's lifetime may be longer than lifetime of `name'
         _get = [state, name]() {
-            lua_getfield(state, -1, name.c_str());
+            lua_pushstring(state, name.c_str());
+            lua_gettable(state, -2);
             lua_remove(state, lua_absindex(state, -2));
         };
         _put = [state, name](Fun fun) {
+            lua_pushstring(state, name.c_str());
             fun();
-            lua_setfield(state, -2, name.c_str());
+            lua_settable(state, -3);
             lua_pop(state, 1);
         };
     }
@@ -418,12 +420,14 @@ public:
         const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
 	// `name' is passed by value because lambda lifetime may be longer than `name'
         _get = [state, name]() {
-            lua_getfield(state, -1, name.c_str());
+            lua_pushstring(state, name.c_str());
+            lua_gettable(state, -2);
             lua_remove(state, lua_absindex(state, -2));
         };
         _put = [state, name](Fun fun) {
+            lua_pushstring(state, name.c_str());
             fun();
-            lua_setfield(state, -2, name.c_str());
+            lua_settable(state, -3);
             lua_pop(state, 1);
         };
         return std::move(*this);
@@ -458,12 +462,14 @@ public:
         const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
 	// `name' is passed by value because lambda lifetime may be longer than `name'
         Fun get = [state, name]() {
-            lua_getfield(state, -1, name.c_str());
+            lua_pushstring(state, name.c_str());
+            lua_gettable(state, -2);
             lua_remove(state, lua_absindex(state, -2));
         };
         PFun put = [state, name](Fun fun) {
+            lua_pushstring(state, name.c_str());
             fun();
-            lua_setfield(state, -2, name.c_str());
+            lua_settable(state, -3);
             lua_pop(state, 1);
         };
         return Selector{_state, _registry, *_exception_handler, n, traversal, get, put};


### PR DESCRIPTION
Remove uses of `std::function` for `Selector::_get` and `Selector::_put` by storing table keys in Lua's registry.