### PR TITLE
Use `make_unique` with `emplace_back` to prevent memory leaks

### DIFF
--- a/include/selene/Class.h
+++ b/include/selene/Class.h
@@ -6,6 +6,7 @@
 #include "MetatableRegistry.h"
 #include <map>
 #include <memory>
+#include "util.h"
 #include <vector>
 #include <stack>
 
@@ -55,16 +56,17 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            new ClassFun<1, T, M>
-            {state, std::string{member_name}, _metatable_name.c_str(), lambda_get});
+            make_unique<ClassFun<1, T, M>>(
+                state, std::string{member_name},
+                _metatable_name.c_str(), lambda_get));
 
         std::function<void(T*, M)> lambda_set = [member](T *t, M value) {
             (t->*member) = value;
         };
         _funs.emplace_back(
-            new ClassFun<0, T, void, M>
-            {state, std::string("set_") + member_name,
-                    _metatable_name.c_str(), lambda_set});
+            make_unique<ClassFun<0, T, void, M>>(
+                state, std::string("set_") + member_name,
+                _metatable_name.c_str(), lambda_set));
     }
 
     template <typename M>
@@ -76,9 +78,9 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            new ClassFun<1, T, M>
-            {state, std::string{member_name},
-                    _metatable_name.c_str(), lambda_get});
+            make_unique<ClassFun<1, T, M>>(
+                state, std::string{member_name},
+                _metatable_name.c_str(), lambda_get));
     }
 
     template <typename Ret, typename... Args>
@@ -90,8 +92,9 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            new ClassFun<arity, T, Ret, Args...>
-            {state, std::string(fun_name), _metatable_name.c_str(), lambda});
+            make_unique<ClassFun<arity, T, Ret, Args...>>(
+                state, std::string(fun_name),
+                _metatable_name.c_str(), lambda));
     }
 
     template <typename Ret, typename... Args>
@@ -103,8 +106,9 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            new ClassFun<arity, T, Ret, Args...>
-            {state, std::string(fun_name), _metatable_name.c_str(), lambda});
+            make_unique<ClassFun<arity, T, Ret, Args...>>(
+                state, std::string(fun_name),
+                _metatable_name.c_str(), lambda));
     }
 
     template <typename Ret, typename... Args>
@@ -117,8 +121,9 @@ private:
             };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            new ClassFun<arity, const T, Ret, Args...>
-            {state, std::string(fun_name), _metatable_name.c_str(), lambda});
+            make_unique<ClassFun<arity, const T, Ret, Args...>>(
+                state, std::string(fun_name),
+                _metatable_name.c_str(), lambda));
     }
 
     void _register_members(lua_State *state) {}

--- a/include/selene/Obj.h
+++ b/include/selene/Obj.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include "util.h"
 #include <utility>
 #include <vector>
 
@@ -35,14 +36,15 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            new ObjFun<1, M>{state, std::string{member_name}, lambda_get});
+            make_unique<ObjFun<1, M>>(
+                state, std::string{member_name}, lambda_get));
 
         std::function<void(M)> lambda_set = [t, member](M value) {
             t->*member = value;
         };
         _funs.emplace_back(
-            new ObjFun<0, void, M>
-            {state, std::string{"set_"} + member_name, lambda_set});
+            make_unique<ObjFun<0, void, M>>(
+                state, std::string{"set_"} + member_name, lambda_set));
     }
 
     template <typename M>
@@ -55,7 +57,8 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            new ObjFun<1, M>{state, std::string{member_name}, lambda_get});
+            make_unique<ObjFun<1, M>>(
+                state, std::string{member_name}, lambda_get));
     }
 
     template <typename Ret, typename... Args>
@@ -68,8 +71,8 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            new ObjFun<arity, Ret, Args...>
-            {state, std::string(fun_name), lambda});
+            make_unique<ObjFun<arity, Ret, Args...>>(
+                state, std::string(fun_name), lambda));
     }
 
     template <typename Ret, typename... Args>
@@ -82,8 +85,8 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            new ObjFun<arity, Ret, Args...>
-            {state, std::string(fun_name), lambda});
+            make_unique<ObjFun<arity, Ret, Args...>>(
+                state, std::string(fun_name), lambda));
     }
 
     void _register_members(lua_State *state, T *t) {}

--- a/include/selene/Registry.h
+++ b/include/selene/Registry.h
@@ -4,6 +4,7 @@
 #include "exotics.h"
 #include "Fun.h"
 #include "Obj.h"
+#include "util.h"
 #include <vector>
 
 namespace sel {
@@ -34,17 +35,17 @@ public:
     template <typename Ret, typename... Args>
     void Register(std::function<Ret(Args...)> fun) {
         constexpr int arity = detail::_arity<Ret>::value;
-        auto tmp = std::unique_ptr<BaseFun>(
-            new Fun<arity, Ret, Args...>{_state, _metatables, fun});
-        _funs.push_back(std::move(tmp));
+        _funs.emplace_back(
+            make_unique<Fun<arity, Ret, Args...>>(
+                _state, _metatables, fun));
     }
 
     template <typename Ret, typename... Args>
     void Register(Ret (*fun)(Args...)) {
         constexpr int arity = detail::_arity<Ret>::value;
-        auto tmp = std::unique_ptr<BaseFun>(
-            new Fun<arity, Ret, Args...>{_state, _metatables, fun});
-        _funs.push_back(std::move(tmp));
+        _funs.emplace_back(
+            make_unique<Fun<arity, Ret, Args...>>(
+                _state, _metatables, fun));
     }
 
     template <typename T, typename... Funs>
@@ -60,9 +61,7 @@ public:
 
     template <typename T, typename... Funs>
     void RegisterObj(T &t, Funs... funs) {
-        auto tmp = std::unique_ptr<BaseObj>(
-            new Obj<T, Funs...>{_state, &t, funs...});
-        _objs.push_back(std::move(tmp));
+        _objs.emplace_back(make_unique<Obj<T, Funs...>>(_state, &t, funs...));
     }
 
     template <typename T, typename... CtorArgs, typename... Funs, size_t... N>
@@ -73,10 +72,9 @@ public:
 
     template <typename T, typename... CtorArgs, typename... Funs>
     void RegisterClassWorker(const std::string &name, Funs... funs) {
-        auto tmp = std::unique_ptr<BaseClass>(
-            new Class<T, Ctor<T, CtorArgs...>, Funs...>
-            {_state, _metatables, name, funs...});
-        _classes.push_back(std::move(tmp));
+        _classes.emplace_back(
+            make_unique<Class<T, Ctor<T, CtorArgs...>, Funs...>>(
+                _state, _metatables, name, funs...));
     }
 };
 }

--- a/include/selene/util.h
+++ b/include/selene/util.h
@@ -2,6 +2,7 @@
 
 #include "exception.h"
 #include <iostream>
+#include <utility>
 
 extern "C" {
 #include <lua.h>
@@ -87,5 +88,10 @@ inline int ErrorHandler(lua_State *L) {
 inline int SetErrorHandler(lua_State *L) {
     lua_pushcfunction(L, &ErrorHandler);
     return lua_gettop(L);
+}
+
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 }


### PR DESCRIPTION
Further replace other uses of explicit new to construct temporary unique_ptr with
make_unique.

[Description of the memory leak](http://stackoverflow.com/questions/15783342/should-i-use-c11-emplace-back-with-pointers-containters).