### PR TITLE
Function call argument leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 
 env:
   - BUILD_TYPE=Release
-  - BUILD_TYPE=RelWithDebInfo VALGRIND='valgrind --leak-check=full --error-exitcode=1'
+  - BUILD_TYPE=Debug VALGRIND='valgrind --leak-check=full --error-exitcode=1'
 
 script:
   - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLUA_INCLUDE_DIR=/usr/include/lua5.2 && make && ${VALGRIND} ./test_runner

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -21,6 +21,7 @@ static TestMap tests = {
     {"test_call_undefined_function", test_call_undefined_function},
     {"test_call_undefined_function2", test_call_undefined_function2},
     {"test_call_stackoverflow", test_call_stackoverflow},
+    {"test_parameter_conversion_error", test_parameter_conversion_error},
 
     {"test_catch_exception_from_callback_within_lua", test_catch_exception_from_callback_within_lua},
     {"test_catch_unknwon_exception_from_callback_within_lua", test_catch_unknwon_exception_from_callback_within_lua},

--- a/test/error_tests.h
+++ b/test/error_tests.h
@@ -73,3 +73,17 @@ bool test_call_stackoverflow(sel::State &state) {
     state["do_overflow"]();
     return capture.Content().find(expected) != std::string::npos;
 }
+
+bool test_parameter_conversion_error(sel::State &state) {
+    const char * expected =
+        "bad argument #2 to 'accept_string_int_string' (number expected, got string)";
+    std::string largeStringToPreventSSO(50, 'x');
+    state["accept_string_int_string"] = [](std::string, int, std::string){};
+
+    CapturedStdout capture;
+    state["accept_string_int_string"](
+        largeStringToPreventSSO,
+        "not a number",
+        largeStringToPreventSSO);
+    return capture.Content().find(expected) != std::string::npos;
+}


### PR DESCRIPTION
Cause: When Selene obtains parameters from Lua to call a registered function it uses `sel::detail::_check_get`. If parameter types don't match Lua raises an exception resulting in a longjump. That in turn skips the destructors of already unpacked parameters.