### PR TITLE
Build and test success with vc++ 2015

### DIFF
--- a/include/selene/Class.h
+++ b/include/selene/Class.h
@@ -56,7 +56,7 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            make_unique<ClassFun<1, T, M>>(
+            sel::make_unique<ClassFun<1, T, M>>(
                 state, std::string{member_name},
                 _metatable_name.c_str(), lambda_get));
 
@@ -64,7 +64,7 @@ private:
             (t->*member) = value;
         };
         _funs.emplace_back(
-            make_unique<ClassFun<0, T, void, M>>(
+            sel::make_unique<ClassFun<0, T, void, M>>(
                 state, std::string("set_") + member_name,
                 _metatable_name.c_str(), lambda_set));
     }
@@ -78,7 +78,7 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            make_unique<ClassFun<1, T, M>>(
+            sel::make_unique<ClassFun<1, T, M>>(
                 state, std::string{member_name},
                 _metatable_name.c_str(), lambda_get));
     }
@@ -92,7 +92,7 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<ClassFun<arity, T, Ret, Args...>>(
+            sel::make_unique<ClassFun<arity, T, Ret, Args...>>(
                 state, std::string(fun_name),
                 _metatable_name.c_str(), lambda));
     }
@@ -106,7 +106,7 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<ClassFun<arity, T, Ret, Args...>>(
+            sel::make_unique<ClassFun<arity, T, Ret, Args...>>(
                 state, std::string(fun_name),
                 _metatable_name.c_str(), lambda));
     }
@@ -121,7 +121,7 @@ private:
             };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<ClassFun<arity, const T, Ret, Args...>>(
+            sel::make_unique<ClassFun<arity, const T, Ret, Args...>>(
                 state, std::string(fun_name),
                 _metatable_name.c_str(), lambda));
     }

--- a/include/selene/Obj.h
+++ b/include/selene/Obj.h
@@ -36,14 +36,14 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            make_unique<ObjFun<1, M>>(
+            sel::make_unique<ObjFun<1, M>>(
                 state, std::string{member_name}, lambda_get));
 
         std::function<void(M)> lambda_set = [t, member](M value) {
             t->*member = value;
         };
         _funs.emplace_back(
-            make_unique<ObjFun<0, void, M>>(
+            sel::make_unique<ObjFun<0, void, M>>(
                 state, std::string{"set_"} + member_name, lambda_set));
     }
 
@@ -57,7 +57,7 @@ private:
             return t->*member;
         };
         _funs.emplace_back(
-            make_unique<ObjFun<1, M>>(
+            sel::make_unique<ObjFun<1, M>>(
                 state, std::string{member_name}, lambda_get));
     }
 
@@ -71,7 +71,7 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<ObjFun<arity, Ret, Args...>>(
+            sel::make_unique<ObjFun<arity, Ret, Args...>>(
                 state, std::string(fun_name), lambda));
     }
 
@@ -85,7 +85,7 @@ private:
         };
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<ObjFun<arity, Ret, Args...>>(
+            sel::make_unique<ObjFun<arity, Ret, Args...>>(
                 state, std::string(fun_name), lambda));
     }
 

--- a/include/selene/Registry.h
+++ b/include/selene/Registry.h
@@ -36,7 +36,7 @@ public:
     void Register(std::function<Ret(Args...)> fun) {
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<Fun<arity, Ret, Args...>>(
+            sel::make_unique<Fun<arity, Ret, Args...>>(
                 _state, _metatables, fun));
     }
 
@@ -44,7 +44,7 @@ public:
     void Register(Ret (*fun)(Args...)) {
         constexpr int arity = detail::_arity<Ret>::value;
         _funs.emplace_back(
-            make_unique<Fun<arity, Ret, Args...>>(
+            sel::make_unique<Fun<arity, Ret, Args...>>(
                 _state, _metatables, fun));
     }
 
@@ -61,7 +61,7 @@ public:
 
     template <typename T, typename... Funs>
     void RegisterObj(T &t, Funs... funs) {
-        _objs.emplace_back(make_unique<Obj<T, Funs...>>(_state, &t, funs...));
+        _objs.emplace_back(sel::make_unique<Obj<T, Funs...>>(_state, &t, funs...));
     }
 
     template <typename T, typename... CtorArgs, typename... Funs, size_t... N>
@@ -73,7 +73,7 @@ public:
     template <typename T, typename... CtorArgs, typename... Funs>
     void RegisterClassWorker(const std::string &name, Funs... funs) {
         _classes.emplace_back(
-            make_unique<Class<T, Ctor<T, CtorArgs...>, Funs...>>(
+            sel::make_unique<Class<T, Ctor<T, CtorArgs...>, Funs...>>(
                 _state, _metatables, name, funs...));
     }
 };

--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -16,6 +16,10 @@ extern "C" {
  */
 
 namespace sel {
+
+template<typename T>
+class function;
+
 namespace detail {
 
 template <typename T>
@@ -36,10 +40,15 @@ struct is_primitive<bool> {
 };
 template <>
 struct is_primitive<lua_Number> {
-    static constexpr bool result = true;
+    static constexpr bool value = true;
 };
 template <>
 struct is_primitive<std::string> {
+    static constexpr bool value = true;
+};
+
+template<typename T>
+struct is_primitive<sel::function<T>> {
     static constexpr bool value = true;
 };
 


### PR DESCRIPTION
Solve the make_unique namespace problem.
Then will build success with vc++ 2015.
But run all test case will let the progrem crash.

The four cases make crash.
```cpp
test_call_exception_handler_while_using_sel_function
test_rethrow_using_sel_function
test_call_returned_lua_function
test_call_multivalue_lua_function
```

The problem is beause of call the wrong overloaded operator method of Selector. Should call **operator sel::function<R(Args...)>()** method, but called **operator T&() const** method in fact.

So added new **is_primitive** method of **sel::function** type to resolve the problem.

Now, run all test case will success with vc++2015.