### PR TITLE
Fixed multiple definition bug.

### DIFF
--- a/include/selene/LuaRef.h
+++ b/include/selene/LuaRef.h
@@ -43,7 +43,7 @@ LuaRef make_Ref(lua_State * state, T&& t) {
 }
 
 namespace detail {
-    void append_ref_recursive(lua_State *, std::vector<LuaRef> &) {}
+    inline void append_ref_recursive(lua_State *, std::vector<LuaRef> &) {}
 
     template <typename Head, typename... Tail>
     void append_ref_recursive(lua_State * state, std::vector<LuaRef> & refs, Head&& head, Tail&&... tail) {


### PR DESCRIPTION
I got linker errors when including LuaRef.h in multiple cpp files. There was a non-inlined, non-template function in the header file. Adding inline fixed the issue.