### PR TITLE
Optimizing LuaRef...

### DIFF
--- a/include/selene/LuaRef.h
+++ b/include/selene/LuaRef.h
@@ -26,6 +26,17 @@ public:
         : LuaRef(state, LUA_REFNIL)
         {}
 
+	LuaRef(const LuaRef &other)
+		: _state(other._state)
+		, _ref(other._ref)
+	{
+		if (_state && _ref != LUA_REFNIL)
+		{
+			other.Push(_state);
+			_ref = luaL_ref(_state, LUA_REGISTRYINDEX);
+		}
+	}
+
 	~LuaRef()
 	{
 		if(_state && _ref != LUA_REFNIL)

--- a/include/selene/LuaRef.h
+++ b/include/selene/LuaRef.h
@@ -12,31 +12,28 @@ extern "C" {
 }
 
 namespace sel {
-namespace detail {
-class LuaRefDeleter {
-private:
-    lua_State *_state;
-public:
-    LuaRefDeleter(lua_State *state) : _state{state} {}
-    void operator()(int *ref) const {
-        luaL_unref(_state, LUA_REGISTRYINDEX, *ref);
-        delete ref;
-    }
-};
-}
 class LuaRef {
 private:
-    std::shared_ptr<int> _ref;
+	lua_State *_state;
+    int _ref;
 public:
     LuaRef(lua_State *state, int ref)
-        : _ref(new int{ref}, detail::LuaRefDeleter{state}) {}
+        : _ref(ref) 
+		, _state(state)
+	{}
 
     LuaRef(lua_State *state)
         : LuaRef(state, LUA_REFNIL)
         {}
 
+	~LuaRef()
+	{
+		if(_state && _ref != LUA_REFNIL)
+			luaL_unref(_state, LUA_REGISTRYINDEX, _ref);
+	}
+
     void Push(lua_State *state) const {
-        lua_rawgeti(state, LUA_REGISTRYINDEX, *_ref);
+        lua_rawgeti(state, LUA_REGISTRYINDEX, _ref);
     }
 };
 

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -68,10 +68,10 @@ private:
         : _state(s), _registry(&r), _exception_handler(&eh), _name(name),
           _key(make_Ref(s, name)) {}
 
-    void _get(LuaRef r) const {
+    void _get(const LuaRef &r) const {
         r.Push(_state);
         lua_gettable(_state, -2);
-        lua_remove(_state, lua_absindex(_state, -2));
+        lua_remove(_state, -2);
     }
 
     // Pushes this element to the stack


### PR DESCRIPTION
No need to use shared_ptr with LuaRef.  You end up allocating more integers on the heap and reference counting them when they'll always be refcounted at 1.  I get the thinking here... to share references to objects and avoid calling luaL_ref and luaL_unref when unneeded.  But the old approach does that as well as allocating on the heap, etc.