### PR TITLE
Replace overloading with template specializations.

### DIFF
--- a/include/selene/BaseFun.h
+++ b/include/selene/BaseFun.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "function.h"
 #include <exception>
 #include "ExceptionHandler.h"
+#include "MetatableRegistry.h"
 #include <functional>
-#include "primitives.h"
 #include <tuple>
+#include "types.h"
 #include "util.h"
 
 namespace sel {

--- a/include/selene/Fun.h
+++ b/include/selene/Fun.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "BaseFun.h"
-#include "primitives.h"
 #include <string>
+#include "types.h"
 
 namespace sel {
 template <int N, typename Ret, typename... Args>
 class Fun : public BaseFun {
 private:
-    using _fun_type = std::function<Ret(detail::decay_primitive<Args>...)>;
+    using _fun_type = std::function<Ret(detail::decay_non_referencable<Args>...)>;
     _fun_type _fun;
 
 public:
@@ -21,8 +21,8 @@ public:
     // Each application of a function receives a new Lua context so
     // this argument is necessary.
     int Apply(lua_State *l) override {
-        std::tuple<detail::decay_primitive<Args>...> args =
-            detail::_get_args<detail::decay_primitive<Args>...>(l);
+        std::tuple<detail::decay_non_referencable<Args>...> args =
+            detail::_get_args<detail::decay_non_referencable<Args>...>(l);
         detail::_push(l, detail::_lift(_fun, args));
         return N;
     }
@@ -32,7 +32,7 @@ public:
 template <typename... Args>
 class Fun<0, void, Args...> : public BaseFun {
 private:
-    using _fun_type = std::function<void(detail::decay_primitive<Args>...)>;
+    using _fun_type = std::function<void(detail::decay_non_referencable<Args>...)>;
     _fun_type _fun;
 
 public:
@@ -45,8 +45,8 @@ public:
     // Each application of a function receives a new Lua context so
     // this argument is necessary.
     int Apply(lua_State *l) {
-        std::tuple<detail::decay_primitive<Args>...> args =
-            detail::_get_args<detail::decay_primitive<Args>...>(l);
+        std::tuple<detail::decay_non_referencable<Args>...> args =
+            detail::_get_args<detail::decay_non_referencable<Args>...>(l);
         detail::_lift(_fun, args);
         return 0;
     }

--- a/include/selene/LuaRef.h
+++ b/include/selene/LuaRef.h
@@ -2,8 +2,7 @@
 
 #include <memory>
 #include <vector>
-#include "primitives.h"
-#include "ResourceHandler.h"
+#include "types.h"
 
 extern "C" {
 #include <lua.h>

--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -4,11 +4,14 @@
 #include "function.h"
 #include <functional>
 #include "LuaRef.h"
+#include "primitives.h"
 #include "references.h"
 #include "Registry.h"
 #include "ResourceHandler.h"
 #include <string>
 #include <tuple>
+#include "tuples.h"
+#include "userdefined.h"
 #include "util.h"
 #include <vector>
 
@@ -291,7 +294,7 @@ public:
     template<
         typename T,
         typename = typename std::enable_if<
-            !detail::is_primitive<typename std::decay<T>::type>::value
+            detail::is_referenceable<T&>::value
         >::type
     >
     operator T&() const {

--- a/include/selene/function.h
+++ b/include/selene/function.h
@@ -2,10 +2,9 @@
 
 #include "ExceptionHandler.h"
 #include "LuaRef.h"
-#include "primitives.h"
-#include "references.h"
 #include "ResourceHandler.h"
 #include <tuple>
+#include "types.h"
 #include "util.h"
 
 namespace sel {
@@ -115,27 +114,25 @@ public:
 
 namespace detail {
 
-template<typename T>
-struct is_primitive<sel::function<T>> {
-    static constexpr bool value = true;
+template<typename R, typename...Args>
+struct type_t<sel::function<R(Args...)>> {
+
+    sel::function<R(Args...)> _get(_id<sel::function<R(Args...)>> id,
+                                   lua_State *l, const int index) {
+        return this->_check_get(id, l, index);
+    }
+
+    sel::function<R(Args...)> _check_get(_id<sel::function<R(Args...)>>,
+                                         lua_State *l, const int index) {
+        lua_pushvalue(l, index);
+        return sel::function<R(Args...)>{luaL_ref(l, LUA_REGISTRYINDEX), l};
+    }
+
+    void _push(lua_State *l, sel::function<R(Args...)> fun) {
+        fun.Push(l);
+    }
+
 };
 
-template <typename R, typename...Args>
-inline sel::function<R(Args...)> _check_get(_id<sel::function<R(Args...)>>,
-                                            lua_State *l, const int index) {
-    lua_pushvalue(l, index);
-    return sel::function<R(Args...)>{luaL_ref(l, LUA_REGISTRYINDEX), l};
-}
-
-template <typename R, typename... Args>
-inline sel::function<R(Args...)> _get(_id<sel::function<R(Args...)>> id,
-                                      lua_State *l, const int index) {
-    return _check_get(id, l, index);
-}
-
-template <typename R, typename... Args>
-inline void _push(lua_State *l, sel::function<R(Args...)> fun) {
-    fun.Push(l);
-}
 }
 }

--- a/include/selene/primitives.h
+++ b/include/selene/primitives.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "ExceptionTypes.h"
 #include <string>
-#include "traits.h"
 #include <type_traits>
-#include "MetatableRegistry.h"
+#include "types.h"
 
 extern "C" {
 #include <lua.h>
@@ -20,101 +18,9 @@ namespace sel {
 
 namespace detail {
 
-template <typename T>
-struct is_primitive {
-    static constexpr bool value = false;
-};
-template <>
-struct is_primitive<int> {
-    static constexpr bool value = true;
-};
-template <>
-struct is_primitive<unsigned int> {
-    static constexpr bool value = true;
-};
-template <>
-struct is_primitive<bool> {
-    static constexpr bool value = true;
-};
-template <>
-struct is_primitive<lua_Number> {
-    static constexpr bool value = true;
-};
-template <>
-struct is_primitive<std::string> {
-    static constexpr bool value = true;
-};
-
-template<typename T>
-using decay_primitive =
-    typename std::conditional<
-        is_primitive<typename std::decay<T>::type>::value,
-        typename std::decay<T>::type,
-        T
-    >::type;
-
-/* getters */
-template <typename T>
-inline T* _get(_id<T*>, lua_State *l, const int index) {
-    if(MetatableRegistry::IsType(l, typeid(T), index)) {
-        return (T*)lua_topointer(l, index);
-    }
-    return nullptr;
-}
-
-template <typename T>
-inline T& _get(_id<T&>, lua_State *l, const int index) {
-    if(!MetatableRegistry::IsType(l, typeid(T), index)) {
-        throw TypeError{
-            MetatableRegistry::GetTypeName(l, typeid(T)),
-            MetatableRegistry::GetTypeName(l, index)
-        };
-    }
-
-    T *ptr = (T*)lua_topointer(l, index);
-    if(ptr == nullptr) {
-        throw TypeError{MetatableRegistry::GetTypeName(l, typeid(T))};
-    }
-    return *ptr;
-}
-
-template <typename T>
-inline typename std::enable_if<
-    !is_primitive<typename std::decay<T>::type>::value, T
->::type
-_get(_id<T>, lua_State *l, const int index) {
-    return _get(_id<T&>{}, l, index);
-}
-
-inline bool _get(_id<bool>, lua_State *l, const int index) {
-    return lua_toboolean(l, index) != 0;
-}
-
-inline int _get(_id<int>, lua_State *l, const int index) {
-    return static_cast<int>(lua_tointeger(l, index));
-}
-
-inline unsigned int _get(_id<unsigned int>, lua_State *l, const int index) {
-#if LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM < 503
-    return lua_tounsigned(l, index);
-#else
-    return static_cast<unsigned>(lua_tointeger(l, index));
-#endif
-}
-
-inline lua_Number _get(_id<lua_Number>, lua_State *l, const int index) {
-    return lua_tonumber(l, index);
-}
-
-inline std::string _get(_id<std::string>, lua_State *l, const int index) {
-    size_t size;
-    const char *buff = lua_tolstring(l, index, &size);
-    return std::string{buff, size};
-}
-
 using _lua_check_get = void (*)(lua_State *l, int index);
 // Throw this on conversion errors to prevent long jumps caused in Lua from
-// bypassing destructors. The outermost function can then call checkd_get(index)
+// bypassing destructors. The outermost function can then call checked_get(index)
 // in a context where a long jump is safe.
 // This way we let Lua generate the error message and use proper stack
 // unwinding.
@@ -123,264 +29,164 @@ struct GetParameterFromLuaTypeError {
     int index;
 };
 
-template <typename T>
-inline T* _check_get(_id<T*>, lua_State *l, const int index) {
-    MetatableRegistry::CheckType(l, typeid(T), index);
-    return (T *)lua_topointer(l, index);
-}
+template<>
+struct type_t<int> {
 
-template <typename T>
-inline T& _check_get(_id<T&>, lua_State *l, const int index) {
-    static_assert(!is_primitive<T>::value,
-                  "Reference types must not be primitives.");
-
-    T *ptr = _check_get(_id<T*>{}, l, index);
-
-    if(ptr == nullptr) {
-        throw GetUserdataParameterFromLuaTypeError{
-            MetatableRegistry::GetTypeName(l, typeid(T)),
-            index
-        };
+    int _get(_id<int>, lua_State *l, const int index) {
+        return static_cast<int>(lua_tointeger(l, index));
     }
 
-    return *ptr;
-}
-
-template <typename T>
-inline typename std::enable_if<
-    !is_primitive<typename std::decay<T>::type>::value, T
->::type
-_check_get(_id<T>, lua_State *l, const int index) {
-    return _check_get(_id<T&>{}, l, index);
-};
-
-template <typename T>
-inline T _check_get(_id<T&&>, lua_State *l, const int index) {
-    return _check_get(_id<T>{}, l, index);
-}
-
-
-inline int _check_get(_id<int>, lua_State *l, const int index) {
+    int _check_get(_id<int>, lua_State *l, const int index) {
 #if LUA_VERSION_NUM >= 502
-    int isNum = 0;
-    auto res = static_cast<int>(lua_tointegerx(l, index, &isNum));
-    if(!isNum){
-        throw GetParameterFromLuaTypeError{
+        int isNum = 0;
+        auto res = static_cast<int>(lua_tointegerx(l, index, &isNum));
+        if(!isNum){
+            throw GetParameterFromLuaTypeError{
 #if LUA_VERSION_NUM >= 503
-            [](lua_State *l, int index){luaL_checkinteger(l, index);},
+                [](lua_State *l, int index){luaL_checkinteger(l, index);},
 #else
-            [](lua_State *l, int index){luaL_checkint(l, index);},
+                    [](lua_State *l, int index){luaL_checkint(l, index);},
 #endif
-            index
-        };
-    }
-    return res;
+                    index
+            };
+        }
+        return res;
 #else
 #error "Not supported for Lua versions <5.2"
 #endif
-}
+    }
 
-inline unsigned int _check_get(_id<unsigned int>, lua_State *l, const int index) {
-    int isNum = 0;
+    void _push(lua_State *l, int i) {
+        lua_pushinteger(l, i);
+    }
+
+};
+
+template<>
+struct type_t<unsigned int> {
+
+    unsigned int _get(_id<unsigned int>, lua_State *l, const int index) {
+#if LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM < 503
+        return lua_tounsigned(l, index);
+#else
+        return static_cast<unsigned>(lua_tointeger(l, index));
+#endif
+    }
+
+    unsigned int _check_get(_id<unsigned int>, lua_State *l, const int index) {
+        int isNum = 0;
 #if LUA_VERSION_NUM >= 503
-    auto res = static_cast<unsigned>(lua_tointegerx(l, index, &isNum));
-    if(!isNum) {
-        throw GetParameterFromLuaTypeError{
-            [](lua_State *l, int index){luaL_checkinteger(l, index);},
-            index
-        };
-    }
+        auto res = static_cast<unsigned>(lua_tointegerx(l, index, &isNum));
+        if(!isNum) {
+            throw GetParameterFromLuaTypeError{
+                [](lua_State *l, int index){luaL_checkinteger(l, index);},
+                    index
+            };
+        }
 #elif LUA_VERSION_NUM >= 502
-    auto res = static_cast<unsigned>(lua_tounsignedx(l, index, &isNum));
-    if(!isNum) {
-        throw GetParameterFromLuaTypeError{
-            [](lua_State *l, int index){luaL_checkunsigned(l, index);},
-            index
-        };
-    }
+        auto res = static_cast<unsigned>(lua_tounsignedx(l, index, &isNum));
+        if(!isNum) {
+            throw GetParameterFromLuaTypeError{
+                [](lua_State *l, int index){luaL_checkunsigned(l, index);},
+                    index
+            };
+        }
 #else
 #error "Not supported for Lua versions <5.2"
 #endif
-    return res;
-}
-
-inline lua_Number _check_get(_id<lua_Number>, lua_State *l, const int index) {
-    int isNum = 0;
-    auto res = lua_tonumberx(l, index, &isNum);
-    if(!isNum){
-        throw GetParameterFromLuaTypeError{
-            [](lua_State *l, int index){luaL_checknumber(l, index);},
-            index
-        };
-    }
-    return res;
-}
-
-inline bool _check_get(_id<bool>, lua_State *l, const int index) {
-    return lua_toboolean(l, index) != 0;
-}
-
-inline std::string _check_get(_id<std::string>, lua_State *l, const int index) {
-    size_t size = 0;
-    char const * buff = lua_tolstring(l, index, &size);
-    if(buff == nullptr) {
-        throw GetParameterFromLuaTypeError{
-            [](lua_State *l, int index){luaL_checkstring(l, index);},
-            index
-        };
-    }
-    return std::string{buff, size};
-}
-
-// Worker type-trait struct to _get_n
-// Getting multiple elements returns a tuple
-template <typename... Ts>
-struct _get_n_impl {
-    using type =  std::tuple<Ts...>;
-
-    template <std::size_t... N>
-    static type worker(lua_State *l,
-                       _indices<N...>) {
-        return std::make_tuple(_get(_id<Ts>{}, l, N + 1)...);
+        return res;
     }
 
-    static type apply(lua_State *l) {
-        return worker(l, typename _indices_builder<sizeof...(Ts)>::type());
-    }
-};
-
-// Getting nothing returns void
-template <>
-struct _get_n_impl<> {
-    using type = void;
-    static type apply(lua_State *) {}
-};
-
-// Getting one element returns an unboxed value
-template <typename T>
-struct _get_n_impl<T> {
-    using type = T;
-    static type apply(lua_State *l) {
-        return _get(_id<T>{}, l, -1);
-    }
-};
-
-template <typename... T>
-typename _get_n_impl<T...>::type _get_n(lua_State *l) {
-    return _get_n_impl<T...>::apply(l);
-}
-
-template <typename T>
-T _pop(_id<T> t, lua_State *l) {
-    T ret =  _get(t, l, -1);
-    lua_pop(l, 1);
-    return ret;
-}
-
-/* Setters */
-
-inline void _push(lua_State *) {}
-
-template <typename T>
-inline void _push(lua_State *l, T* t) {
-  if(t == nullptr) {
-    lua_pushnil(l);
-  }
-  else {
-    lua_pushlightuserdata(l, t);
-    MetatableRegistry::SetMetatable(l, typeid(T));
-  }
-}
-
-template <typename T>
-inline typename std::enable_if<
-    !is_primitive<typename std::decay<T>::type>::value
->::type
-_push(lua_State *l, T& t) {
-    lua_pushlightuserdata(l, &t);
-    MetatableRegistry::SetMetatable(l, typeid(T));
-}
-
-template <typename T>
-inline typename std::enable_if<
-    !is_primitive<typename std::decay<T>::type>::value
-    && std::is_rvalue_reference<T&&>::value
->::type
-_push(lua_State *l, T&& t) {
-    if(!MetatableRegistry::IsRegisteredType(l, typeid(t)))
-    {
-        throw CopyUnregisteredType(typeid(t));
-    }
-
-    void *addr = lua_newuserdata(l, sizeof(T));
-    new(addr) T(std::forward<T>(t));
-    MetatableRegistry::SetMetatable(l, typeid(T));
-}
-
-inline void _push(lua_State *l, bool b) {
-    lua_pushboolean(l, b);
-}
-
-inline void _push(lua_State *l, int i) {
-    lua_pushinteger(l, i);
-}
-
-inline void _push(lua_State *l, unsigned int u) {
+    void _push(lua_State *l, unsigned int u) {
 #if LUA_VERSION_NUM >= 503
-  lua_pushinteger(l, (lua_Integer)u);
+        lua_pushinteger(l, (lua_Integer)u);
 #elif LUA_VERSION_NUM >= 502
-    lua_pushunsigned(l, u);
+        lua_pushunsigned(l, u);
 #else
-    lua_pushinteger(l, static_cast<int>(u));
+        lua_pushinteger(l, static_cast<int>(u));
 #endif
-}
+    }
 
-inline void _push(lua_State *l, lua_Number f) {
-    lua_pushnumber(l, f);
-}
+};
 
-inline void _push(lua_State *l, const std::string &s) {
-    lua_pushlstring(l, s.c_str(), s.size());
-}
+template<>
+struct type_t<bool> {
 
-inline void _push(lua_State *l, const char *s) {
-    lua_pushstring(l, s);
-}
+    bool _get(_id<bool>, lua_State *l, const int index) {
+        return lua_toboolean(l, index) != 0;
+    }
 
-template <typename T>
-inline void _set(lua_State *l, T &&value, const int index) {
-    _push(l, std::forward<T>(value));
-    lua_replace(l, index);
-}
+    bool _check_get(_id<bool> id, lua_State *l, const int index) {
+        return this->_get(id, l, index);
+    }
 
-inline void _push_n(lua_State *) {}
+    void _push(lua_State *l, bool b) {
+        lua_pushboolean(l, b);
+    }
 
-template <typename T, typename... Rest>
-inline void _push_n(lua_State *l, T &&value, Rest&&... rest) {
-    _push(l, std::forward<T>(value));
-    _push_n(l, std::forward<Rest>(rest)...);
-}
+};
 
-template <typename... T, std::size_t... N>
-inline void _push_dispatcher(lua_State *l,
-                             const std::tuple<T...> &values,
-                             _indices<N...>) {
-    _push_n(l, std::get<N>(values)...);
-}
+template<>
+struct type_t<lua_Number> {
 
-inline void _push(lua_State *, std::tuple<>) {}
+    lua_Number _get(_id<lua_Number>, lua_State *l, const int index) {
+        return lua_tonumber(l, index);
+    }
 
-template <typename... T>
-inline void _push(lua_State *l, const std::tuple<T...> &values) {
-    constexpr int num_values = sizeof...(T);
-    _push_dispatcher(l, values,
-                     typename _indices_builder<num_values>::type());
-}
+    lua_Number _check_get(_id<lua_Number>, lua_State *l, const int index) {
+        int isNum = 0;
+        auto res = lua_tonumberx(l, index, &isNum);
+        if(!isNum){
+            throw GetParameterFromLuaTypeError{
+                [](lua_State *l, int index){luaL_checknumber(l, index);},
+                    index
+            };
+        }
+        return res;
+    }
 
-template <typename... T>
-inline void _push(lua_State *l, std::tuple<T...> &&values) {
-    _push(l, const_cast<const std::tuple<T...> &>(values));
-}
+    inline void _push(lua_State *l, lua_Number f) {
+        lua_pushnumber(l, f);
+    }
+
+};
+
+template<>
+struct type_t<std::string> {
+
+    std::string _get(_id<std::string>, lua_State *l, const int index) {
+        size_t size;
+        const char *buff = lua_tolstring(l, index, &size);
+        return std::string{buff, size};
+    }
+
+    std::string _check_get(_id<std::string>, lua_State *l, const int index) {
+        size_t size = 0;
+        char const * buff = lua_tolstring(l, index, &size);
+        if(buff == nullptr) {
+            throw GetParameterFromLuaTypeError{
+                [](lua_State *l, int index){luaL_checkstring(l, index);},
+                    index
+            };
+        }
+        return std::string{buff, size};
+    }
+
+    void _push(lua_State *l, const std::string &s) {
+        lua_pushlstring(l, s.c_str(), s.size());
+    }
+
+};
+
+// It should be possible to add referenceable_tag and implement _get and _check_get.
+template<>
+struct type_t<const char *> {
+
+    void _push(lua_State *l, const char *s) {
+        lua_pushstring(l, s);
+    }
+
+};
 
 }
 }

--- a/include/selene/traits.h
+++ b/include/selene/traits.h
@@ -34,6 +34,5 @@ struct _indices_builder<0, Is...> {
     using type = _indices<Is...>;
 };
 
-template <typename T> struct _id {};
 }
 }

--- a/include/selene/tuples.h
+++ b/include/selene/tuples.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <tuple>
+#include "traits.h"
+#include "types.h"
+
+namespace sel {
+
+namespace detail {
+
+template<typename... T>
+struct type_t<std::tuple<T...>> {
+
+    template <std::size_t... N>
+    void _push_dispatcher(lua_State *l,
+                          const std::tuple<T...> &values,
+                          _indices<N...>) {
+        ::sel::detail::_push_n(l, std::get<N>(values)...);
+    }
+
+    void _push(lua_State *l, const std::tuple<T...> &values) {
+        constexpr int num_values = sizeof...(T);
+        this->_push_dispatcher(l, values,
+                               typename _indices_builder<num_values>::type());
+    }
+
+};
+
+}
+
+}

--- a/include/selene/types.h
+++ b/include/selene/types.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "traits.h"
+#include <type_traits>
+
+extern "C" {
+#include <lua.h>
+#include <lauxlib.h>
+#include <lualib.h>
+}
+
+namespace sel {
+
+namespace detail{
+
+template<typename T>
+struct type_t;
+
+template <typename T>
+using type = type_t<typename std::decay<T>::type>;
+
+// Marks types Lua offers raw pointer access to.
+struct referenceable_tag {};
+
+template <typename T>
+using is_referenceable = typename std::is_base_of<referenceable_tag, type<T>>::type;
+
+template <typename T>
+using decay_non_referencable =
+    typename std::conditional<
+        is_referenceable<T>::value,
+        T,
+        typename std::decay<T>::type
+    >::type;
+
+template <typename T> struct _id {};
+
+template<typename T>
+T _get(_id<T> id, lua_State *l, const int index) {
+    return type<T>{}._get(id, l, index);
+}
+
+template<typename T>
+T _check_get(_id<T> id, lua_State *l, const int index) {
+    return type<T>{}._check_get(id, l, index);
+}
+
+// Worker type-trait struct to _get_n
+// Getting multiple elements returns a tuple
+template <typename... Ts>
+struct _get_n_impl {
+    using type = std::tuple<Ts...>;
+
+    template <std::size_t... N>
+    static type worker(lua_State *l,
+                       _indices<N...>) {
+        return std::make_tuple(::sel::detail::_get(_id<Ts>{}, l, N + 1)...);
+    }
+
+    static type apply(lua_State *l) {
+        return worker(l, typename _indices_builder<sizeof...(Ts)>::type());
+    }
+};
+
+// Getting nothing returns void
+template <>
+struct _get_n_impl<> {
+    using type = void;
+    static type apply(lua_State *) {}
+};
+
+// Getting one element returns an unboxed value
+template <typename T>
+struct _get_n_impl<T> {
+    using type = T;
+    static type apply(lua_State *l) {
+        return ::sel::detail::_get(_id<T>{}, l, -1);
+    }
+};
+
+template <typename... T>
+typename _get_n_impl<T...>::type _get_n(lua_State *l) {
+    return _get_n_impl<T...>::apply(l);
+}
+
+template <typename T>
+T _pop(_id<T> id, lua_State *l) {
+    T ret =  ::sel::detail::_get(id, l, -1);
+    lua_pop(l, 1);
+    return ret;
+}
+
+template <typename T>
+void _push(lua_State *l, T&& t) {
+    type<T>{}._push(l, std::forward<T>(t));
+}
+
+inline void _push_n(lua_State *) {}
+
+template <typename T, typename... Rest>
+inline void _push_n(lua_State *l, T &&value, Rest&&... rest) {
+    ::sel::detail::_push(l, std::forward<T>(value));
+    ::sel::detail::_push_n(l, std::forward<Rest>(rest)...);
+}
+}
+
+}

--- a/include/selene/userdefined.h
+++ b/include/selene/userdefined.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "ExceptionTypes.h"
+#include "MetatableRegistry.h"
+#include "types.h"
+
+extern "C" {
+#include <lua.h>
+#include <lauxlib.h>
+#include <lualib.h>
+}
+
+namespace sel {
+
+namespace detail {
+
+template<typename T>
+struct type_t<T*> : referenceable_tag {
+
+    T* _get(_id<T*>, lua_State *l, const int index) {
+        if(MetatableRegistry::IsType(l, typeid(T), index)) {
+            return (T*)lua_topointer(l, index);
+        }
+        return nullptr;
+    }
+
+    T* _check_get(_id<T*>, lua_State *l, const int index) {
+        MetatableRegistry::CheckType(l, typeid(T), index);
+        return (T *)lua_topointer(l, index);
+    }
+
+    void _push(lua_State *l, T* t) {
+        if(t == nullptr) {
+            lua_pushnil(l);
+        }
+        else {
+            lua_pushlightuserdata(l, t);
+            MetatableRegistry::SetMetatable(l, typeid(T));
+        }
+    }
+
+};
+
+template<typename T>
+struct type_t : referenceable_tag {
+
+    T& _get(_id<T&>, lua_State *l, const int index) {
+        if(!MetatableRegistry::IsType(l, typeid(T), index)) {
+            throw TypeError{
+                MetatableRegistry::GetTypeName(l, typeid(T)),
+                    MetatableRegistry::GetTypeName(l, index)
+            };
+        }
+
+        T *ptr = (T*)lua_topointer(l, index);
+        if(ptr == nullptr) {
+            throw TypeError{MetatableRegistry::GetTypeName(l, typeid(T))};
+        }
+        return *ptr;
+    }
+
+    T _get(_id<T>, lua_State *l, const int index) {
+        return this->_get(_id<T&>{}, l, index);
+    }
+
+    T& _check_get(_id<T&>, lua_State *l, const int index) {
+        T *ptr = sel::detail::_check_get(_id<T*>{}, l, index);
+
+        if(ptr == nullptr) {
+            throw GetUserdataParameterFromLuaTypeError{
+                MetatableRegistry::GetTypeName(l, typeid(T)),
+                    index
+            };
+        }
+
+        return *ptr;
+    }
+
+    T _check_get(_id<T>, lua_State *l, const int index) {
+        return this->_check_get(_id<T&>{}, l, index);
+    };
+
+    void _push(lua_State *l, T& t) {
+        lua_pushlightuserdata(l, &t);
+        MetatableRegistry::SetMetatable(l, typeid(T));
+    }
+
+    void _push(lua_State *l, T&& t) {
+        if(!MetatableRegistry::IsRegisteredType(l, typeid(t)))
+        {
+            throw CopyUnregisteredType(typeid(t));
+        }
+
+        void *addr = lua_newuserdata(l, sizeof(T));
+        new(addr) T(std::forward<T>(t));
+        MetatableRegistry::SetMetatable(l, typeid(T));
+    }
+
+};
+
+}
+
+}

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -151,6 +151,8 @@ static TestMap tests = {
     {"test_function_call_with_wrong_ref", test_function_call_with_wrong_ref},
     {"test_function_call_with_wrong_ptr", test_function_call_with_wrong_ptr},
     {"test_function_get_registered_class_by_value", test_function_get_registered_class_by_value},
+    {"test_function_roundtrip", test_function_roundtrip},
+    {"test_reference_roundtrip", test_reference_roundtrip},
 };
 
 // Executes all tests and returns the number of failures.

--- a/test/reference_tests.h
+++ b/test/reference_tests.h
@@ -183,3 +183,19 @@ bool test_function_get_registered_class_by_value(sel::State &state) {
 
     return foo.getX() == 4;
 }
+
+bool test_function_roundtrip(sel::State &state) {
+    state.Load("../test/test_ref.lua");
+    sel::function<void(void)> foo = state["foo"];
+    return state["is_function_foo"](foo);
+}
+
+bool test_reference_roundtrip(sel::State &state) {
+    state["Bar"].SetClass<FunctionBar>();
+    state("bar = Bar.new()");
+    state("function is_bar(candidate) return bar == candidate end");
+
+    sel::Reference<FunctionBar> bar = state["bar"];
+
+    return state["is_bar"](bar);
+}

--- a/test/test_ref.lua
+++ b/test/test_ref.lua
@@ -33,3 +33,7 @@ end
 function return_two()
    return 1, 2
 end
+
+function is_function_foo(candidate)
+   return foo == candidate
+end


### PR DESCRIPTION
Define the interface for types in the new `types.h`. This includes functions like `_get`, `_checked_get` and `_push` as well as `_get_n` and `_push_n`. The notion of primitive types, to define types not being able to get a raw pointer to from Lua, is inverted and has changed to `is_referenceable`.

Split specializations of different kind of types from `primitives.h` into
separate header files: `primitives.h`, `tuples.h` and `userdefined.h`.