### PR TITLE
Add #include <string> to ExceptionTypes.h

### DIFF
--- a/include/selene/ExceptionTypes.h
+++ b/include/selene/ExceptionTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <exception>
+#include <string>
 #include <utility>
 
 namespace sel {


### PR DESCRIPTION
Fixes build error on Mac OS/clang.
