### PR TITLE
Expose internal lua_State for custom Lua functions and allow executing from a string

### DIFF
--- a/include/selene/Selector.h
+++ b/include/selene/Selector.h
@@ -186,8 +186,8 @@ public:
     template <typename... Args>
     const Selector operator()(Args&&... args) const {
         Selector copy{*this};
-        const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
-        const auto eh = _exception_handler;
+        //const auto state = _state; // gcc-5.1 doesn't support implicit member capturing
+        //const auto eh = _exception_handler;
         copy._functor_arguments = make_Refs(_state, std::forward<Args>(args)...);
         copy._functor_active = true;
         return copy;

--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -18,7 +18,7 @@ private:
     std::unique_ptr<Registry> _registry;
     std::unique_ptr<ExceptionHandler> _exception_handler;
 
-    bool executeState(const int status) {
+    bool executeState(int status) {
         #if LUA_VERSION_NUM >= 502
             auto const lua_ok = LUA_OK;
         #else
@@ -27,10 +27,10 @@ private:
         if (status != lua_ok) {
             if (status == LUA_ERRSYNTAX) {
                 const char *msg = lua_tostring(_l, -1);
-                _exception_handler->Handle(status, msg ? msg : file + ": syntax error");
+                _exception_handler->Handle(status, msg ? msg : " syntax error");
             } else if (status == LUA_ERRFILE) {
                 const char *msg = lua_tostring(_l, -1);
-                _exception_handler->Handle(status, msg ? msg : file + ": file error");
+                _exception_handler->Handle(status, msg ? msg : " file error");
             }
             return false;
         }
@@ -41,7 +41,7 @@ private:
         }
 
         const char *msg = lua_tostring(_l, -1);
-        _exception_handler->Handle(status, msg ? msg : file + ": dofile failed");
+        _exception_handler->Handle(status, msg ? msg : "Failed to execute Lua script");
         return false;
     }
 

--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -18,6 +18,33 @@ private:
     std::unique_ptr<Registry> _registry;
     std::unique_ptr<ExceptionHandler> _exception_handler;
 
+    bool executeState(const int status) {
+        #if LUA_VERSION_NUM >= 502
+            auto const lua_ok = LUA_OK;
+        #else
+            auto const lua_ok = 0;
+        #endif
+        if (status != lua_ok) {
+            if (status == LUA_ERRSYNTAX) {
+                const char *msg = lua_tostring(_l, -1);
+                _exception_handler->Handle(status, msg ? msg : file + ": syntax error");
+            } else if (status == LUA_ERRFILE) {
+                const char *msg = lua_tostring(_l, -1);
+                _exception_handler->Handle(status, msg ? msg : file + ": file error");
+            }
+            return false;
+        }
+
+        status = lua_pcall(_l, 0, LUA_MULTRET, 0);
+        if(status == lua_ok) {
+            return true;
+        }
+
+        const char *msg = lua_tostring(_l, -1);
+        _exception_handler->Handle(status, msg ? msg : file + ": dofile failed");
+        return false;
+    }
+
 public:
     State() : State(false) {}
     State(bool should_open_libs) : _l(nullptr), _l_owner(true), _exception_handler(new ExceptionHandler) {
@@ -61,31 +88,20 @@ public:
 
     bool Load(const std::string &file) {
         ResetStackOnScopeExit savedStack(_l);
-        int status = luaL_loadfile(_l, file.c_str());
-#if LUA_VERSION_NUM >= 502
-        auto const lua_ok = LUA_OK;
-#else
-        auto const lua_ok = 0;
-#endif
-        if (status != lua_ok) {
-            if (status == LUA_ERRSYNTAX) {
-                const char *msg = lua_tostring(_l, -1);
-                _exception_handler->Handle(status, msg ? msg : file + ": syntax error");
-            } else if (status == LUA_ERRFILE) {
-                const char *msg = lua_tostring(_l, -1);
-                _exception_handler->Handle(status, msg ? msg : file + ": file error");
-            }
-            return false;
-        }
+        const int status = luaL_loadfile(_l, file.c_str());
 
-        status = lua_pcall(_l, 0, LUA_MULTRET, 0);
-        if(status == lua_ok) {
-            return true;
-        }
+        return executeState(status);
+    }
 
-        const char *msg = lua_tostring(_l, -1);
-        _exception_handler->Handle(status, msg ? msg : file + ": dofile failed");
-        return false;
+    bool loadString(const std::string script) {
+        ResetStackOnScopeExit savedStack(_l);
+        const int status = luaL_loadstring(_l, script.c_str());
+
+        return executeState(status);
+    }
+
+    lua_State* getState() {
+        return _l;
     }
 
     void OpenLib(const std::string& modname, lua_CFunction openf) {


### PR DESCRIPTION
I particularly needed this because I needed to control execution in a sandbox using lua_sethook(). Equally, being able to load directly from an std::string can be very useful. Also, a general maintenance fix to remove a compiler warning about unused variables, Ubuntu ships with GCC 5.4 now anyways. 