### PR TITLE
Enable loading from streams (e.g. std::cin or file streams)

### DIFF
--- a/include/selene/State.h
+++ b/include/selene/State.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <sstream>
 #include "Registry.h"
 #include "Selector.h"
 #include <tuple>
@@ -86,6 +87,12 @@ public:
         const char *msg = lua_tostring(_l, -1);
         _exception_handler->Handle(status, msg ? msg : file + ": dofile failed");
         return false;
+    }
+
+    bool Load(std::istream& stream) {
+        std::stringstream buffer;
+        buffer << stream.rdbuf();
+        this->operator()(buffer.str().c_str());
     }
 
     void OpenLib(const std::string& modname, lua_CFunction openf) {

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -65,6 +65,8 @@ static TestMap tests = {
     {"test_call_with_primitive_by_value", test_call_with_primitive_by_value},
     {"test_call_with_primitive_by_const_ref", test_call_with_primitive_by_const_ref},
     {"test_call_with_primitive_by_rvalue_ref", test_call_with_primitive_by_rvalue_ref},
+    {"test_fstream_input", test_fstream_input},
+    {"test_sstream_input", test_sstream_input},
 
     {"test_metatable_registry_ptr", test_metatable_registry_ptr},
     {"test_metatable_registry_ref", test_metatable_registry_ref},

--- a/test/interop_tests.h
+++ b/test/interop_tests.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <selene.h>
 #include <string>
+#include <fstream>
 
 int my_add(int a, int b) {
     return a + b;
@@ -310,4 +311,16 @@ bool test_call_with_primitive_by_rvalue_ref(sel::State & state) {
     state["test"] = accept_int_by_rvalue_ref;
     state["test"](5);
     return success;
+}
+
+bool test_fstream_input(sel::State &state) {
+    std::ifstream ifs("../test/test.lua");
+    state.Load(ifs);
+    return state["global1"] == 5;
+}
+
+bool test_sstream_input(sel::State &state) {
+    std::istringstream iss("x = 5");
+    state.Load(iss);
+    return state["x"] == 5;
 }


### PR DESCRIPTION
This PR will enable loading of Lua chunks from streams.  With help of this one can write programs which take Lua code via stdin, i.e. `./a.out < script.lua`.  The following code illustrates this.
````cpp
#include <selene.h>
#include <iostream>

int main()
{
  sel::State L{true};
  L.Load(std::cin);
  // ...
}
````